### PR TITLE
Add support for delegates so that downstream plugins can be supported

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -16,13 +16,14 @@ type NetConf struct {
 	VlanQoS       int    `json:"vlanQoS"`
 	DeviceID      string `json:"deviceID"` // PCI address of a VF in valid sysfs format
 	VFID          int
-	HostIFNames   string // VF netdevice name(s)
-	ContIFNames   string // VF names after in the container; used during deletion
-	MinTxRate     *int   `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
-	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
-	SpoofChk      string `json:"spoofchk,omitempty"`   // on|off
-	Trust         string `json:"trust,omitempty"`      // on|off
-	LinkState     string `json:"link_state,omitempty"` // auto|enable|disable
+	HostIFNames   string          // VF netdevice name(s)
+	ContIFNames   string          // VF names after in the container; used during deletion
+	MinTxRate     *int            `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
+	MaxTxRate     *int            `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
+	SpoofChk      string          `json:"spoofchk,omitempty"`   // on|off
+	Trust         string          `json:"trust,omitempty"`      // on|off
+	LinkState     string          `json:"link_state,omitempty"` // auto|enable|disable
+	Delegates     []types.NetConf `json:"delegates"`
 	RuntimeConfig struct {
 		Mac string `json:"mac,omitempty"`
 	} `json:"runtimeConfig,omitempty"`


### PR DESCRIPTION
Added support for 'delegates'. Delegates is just the same as what exists in Multus and can be used to execute downstream chain of plugins. In my particular use-case, I need to execute sbr.
An example of how to specify delegates:
```
kind: NetworkAttachmentDefinition
metadata:
  name: sriov-net1
  annotations:
    k8s.v1.cni.cncf.io/resourceName: intel.com/mlnx_sriov_rdma1
spec:
  config: '{
  "type": "sriov",
  "cniVersion": "0.3.1",
  "name": "sriov-network",
  "delegates": [
          {
                  "cniVersion": "0.3.1",
                  "type": "sbr",
                  "name": "sbr"
          }
  ]
}
```
With the above example, I am able to invoke a subsequent CNI plugin and configure the routing on the pod.


This is a PR to replace #90 and adds support for delegates only as suggested in this comment: https://github.com/intel/sriov-cni/pull/90#issuecomment-551056995
Other parts of the original PR will be put up in a separate request.

Thanks to @aleksandrnull for the help.
Attn: @ahalim-intel 