### PR TITLE
Add support for VFs within a VM

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,11 +27,17 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 	if n.DeviceID != "" {
 		// Get rest of the VF information
 		pfName, vfID, err := getVfInfo(n.DeviceID)
-		if err != nil {
-			return nil, fmt.Errorf("LoadConf(): failed to get VF information: %q", err)
+
+		// Check to see if there is a PF linked to the VF, if there isn't then this is a VF within a VM
+		// so continue without setting the master.
+		if pfName != "" {
+			if err != nil {
+				return nil, fmt.Errorf("LoadConf(): failed to get VF information: %q", err)
+			}
+
+			n.VFID = vfID
+			n.Master = pfName
 		}
-		n.VFID = vfID
-		n.Master = pfName
 	} else {
 		return nil, fmt.Errorf("LoadConf(): VF pci addr is required")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,18 +25,20 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 
 	// DeviceID takes precedence; if we are given a VF pciaddr then work from there
 	if n.DeviceID != "" {
-		// Get rest of the VF information
-		pfName, vfID, err := getVfInfo(n.DeviceID)
 
-		// Check to see if there is a PF linked to the VF, if there isn't then this is a VF within a VM
-		// so continue without setting the master.
-		if pfName != "" {
+		// First try and get the PF name, it is valid to not find the PF, in that case the VF is running within a VM
+		pf, err := utils.GetPfName(n.DeviceID)
+		if err == nil {
+			var vfID int
+
+			// Get the rest of the VF information
+			vfID, err = utils.GetVfid(n.DeviceID, pf)
 			if err != nil {
 				return nil, fmt.Errorf("LoadConf(): failed to get VF information: %q", err)
 			}
 
 			n.VFID = vfID
-			n.Master = pfName
+			n.Master = pf
 		}
 	} else {
 		return nil, fmt.Errorf("LoadConf(): VF pci addr is required")
@@ -82,23 +84,6 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 	}
 
 	return n, nil
-}
-
-func getVfInfo(vfPci string) (string, int, error) {
-
-	var vfID int
-
-	pf, err := utils.GetPfName(vfPci)
-	if err != nil {
-		return "", vfID, err
-	}
-
-	vfID, err = utils.GetVfid(vfPci, pf)
-	if err != nil {
-		return "", vfID, err
-	}
-
-	return pf, vfID, nil
 }
 
 // LoadConfFromCache retrieves cached NetConf returns it along with a handle for removal

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,14 +62,4 @@ var _ = Describe("Config", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	Context("Checking getVfInfo function", func() {
-		It("Assuming existing PF", func() {
-			_, _, err := getVfInfo("0000:af:06.0")
-			Expect(err).NotTo(HaveOccurred())
-		})
-		It("Assuming not existing PF", func() {
-			_, _, err := getVfInfo("0000:af:07.0")
-			Expect(err).To(HaveOccurred())
-		})
-	})
 })


### PR DESCRIPTION
Currently when you have a request for a VF it requires that the PF is present on the system, however in the case of VMs the PF is present on the host and the VF is present in the VM, so the SRIOV plugin does not work. This change allows a VF to be used if there is no PF associated with it, as long as there is no config requested which requires the PF to set it up.