### PR TITLE
Fix shell script finding

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -10,20 +10,20 @@ SRIOV_BIN_FILE="/usr/bin/sriov"
 # Give help text for parameters.
 usage()
 {
-    /bin/echo -e "This is an entrypoint script for SR-IOV CNI to overlay its"
-    /bin/echo -e "binary into location in a filesystem. The binary file will"
-    /bin/echo -e "be copied to the corresponding directory."
-    /bin/echo -e ""
-    /bin/echo -e "./entrypoint.sh"
-    /bin/echo -e "\t-h --help"
-    /bin/echo -e "\t--cni-bin-dir=$CNI_BIN_DIR"
-    /bin/echo -e "\t--sriov-bin-file=$SRIOV_BIN_FILE"
+    printf "This is an entrypoint script for SR-IOV CNI to overlay its\n"
+    printf "binary into location in a filesystem. The binary file will\n"
+    printf "be copied to the corresponding directory.\n"
+    printf "\n"
+    printf "./entrypoint.sh\n"
+    printf "\t-h --help\n"
+    printf "\t--cni-bin-dir=%s\n" $CNI_BIN_DIR
+    printf "\t--sriov-bin-file=%s\n" $SRIOV_BIN_FILE
 }
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
-    PARAM=`echo $1 | awk -F= '{print $1}'`
-    VALUE=`echo $1 | awk -F= '{print $2}'`
+    PARAM=$(echo "$1" | awk -F= '{print $1}')
+    VALUE=$(echo "$1" | awk -F= '{print $2}')
     case $PARAM in
         -h | --help)
             usage
@@ -55,7 +55,7 @@ do
 done
 
 # Copy file into proper place.
-cp -f $SRIOV_BIN_FILE $CNI_BIN_DIR
+cp -f "$SRIOV_BIN_FILE" "$CNI_BIN_DIR"
 
 echo "Entering sleep... (success)"
 


### PR DESCRIPTION
This PR fixes issues found by shellcheck in the bash script `entrypoint.sh`

- SC2006: Use $(..) instead of legacy ...
- SC2039: In POSIX sh, echo flags are not supported.
- SC2086: Double quote to prevent globbing and word splitting.