### PR TITLE
update repository with NPWG git repos URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Package related
 BINARY_NAME=sriov
 PACKAGE=sriov-cni
-ORG_PATH=github.com/intel
+ORG_PATH=github.com/k8snetworkplumbingwg
 REPO_PATH=$(ORG_PATH)/$(PACKAGE)
 GOPATH=$(CURDIR)/.gopath
 GOBIN=$(CURDIR)/bin

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/intel/sriov-cni.svg?branch=master)](https://travis-ci.org/intel/sriov-cni) [![Go Report Card](https://goreportcard.com/badge/github.com/intel/sriov-cni)](https://goreportcard.com/report/github.com/intel/sriov-cni)
+[![Build Status](https://travis-ci.org/k8snetworkplumbingwg/sriov-cni.svg?branch=master)](https://travis-ci.org/k8snetworkplumbingwg/sriov-cni) [![Go Report Card](https://goreportcard.com/badge/github.com/k8snetworkplumbingwg/sriov-cni)](https://goreportcard.com/report/github.com/k8snetworkplumbingwg/sriov-cni)
 
    * [SR-IOV CNI plugin](#sr-iov-cni-plugin)
       * [Build](#build)
@@ -17,7 +17,7 @@ This plugin enables the configuration and usage of SR-IOV VF networks in contain
 
 Network Interface Cards (NICs) with [SR-IOV](http://blog.scottlowe.org/2009/12/02/what-is-sr-iov/) capabilities are managed through physical functions (PFs) and virtual functions (VFs). A PF is used by the host and usually represents a single NIC port. VF configurations are applied through the PF. With SR-IOV CNI each VF can be treated as a separate network interface, assigned to a container, and configured with it's own MAC, VLAN IP and more.
 
-SR-IOV CNI plugin works with [SR-IOV device plugin](https://github.com/intel/sriov-network-device-plugin) for VF allocation in Kubernetes. A metaplugin such as [Multus](https://github.com/intel/multus-cni) gets the allocated VF's `deviceID`(PCI address) and is responsible for invoking the SR-IOV CNI plugin with that `deviceID`.
+SR-IOV CNI plugin works with [SR-IOV device plugin](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin) for VF allocation in Kubernetes. A metaplugin such as [Multus](https://github.com/intel/multus-cni) gets the allocated VF's `deviceID`(PCI address) and is responsible for invoking the SR-IOV CNI plugin with that `deviceID`.
 
 ## Build
 
@@ -32,15 +32,15 @@ make
 Upon successful build the plugin binary will be available in `build/sriov`.
 
 ## Kubernetes Quick Start
-A full guide on orchestrating SR-IOV virtual functions in Kubernetes can be found at the [SR-IOV Device Plugin project.](https://github.com/intel/sriov-network-device-plugin#quick-start)
+A full guide on orchestrating SR-IOV virtual functions in Kubernetes can be found at the [SR-IOV Device Plugin project.](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin#quick-start)
 
-Creating VFs is outside the scope of the SR-IOV CNI plugin. [More information about allocating VFs on different NICs can be found here](https://github.com/intel/sriov-network-device-plugin/blob/master/docs/vf-setup.md)
+Creating VFs is outside the scope of the SR-IOV CNI plugin. [More information about allocating VFs on different NICs can be found here](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/blob/master/docs/vf-setup.md)
 
 To deploy SR-IOV CNI by itself on a Kubernetes 1.16+ cluster:
 
 `kubectl apply -f images/k8s-v1.16/sriov-cni-daemonset.yaml`
 
-**Note** The above deployment is not sufficient to manage and configure SR-IOV virtual functions. [See the full orchestration guide for more information.](https://github.com/intel/sriov-network-device-plugin#sr-iov-network-device-plugin)
+**Note** The above deployment is not sufficient to manage and configure SR-IOV virtual functions. [See the full orchestration guide for more information.](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin#sr-iov-network-device-plugin)
 
 
 ## Usage

--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -11,9 +11,9 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/intel/sriov-cni/pkg/config"
-	"github.com/intel/sriov-cni/pkg/sriov"
-	"github.com/intel/sriov-cni/pkg/utils"
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/config"
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/sriov"
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 	"github.com/vishvananda/netlink"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/intel/sriov-cni
+module github.com/k8snetworkplumbingwg/sriov-cni
 
 go 1.13
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	sriovtypes "github.com/intel/sriov-cni/pkg/types"
-	"github.com/intel/sriov-cni/pkg/utils"
+	sriovtypes "github.com/k8snetworkplumbingwg/sriov-cni/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 )
 
 var (

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -3,7 +3,7 @@ package config
 import (
 	"testing"
 
-	"github.com/intel/sriov-cni/pkg/utils"
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 
-	sriovtypes "github.com/intel/sriov-cni/pkg/types"
-	"github.com/intel/sriov-cni/pkg/utils"
+	sriovtypes "github.com/k8snetworkplumbingwg/sriov-cni/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 	"github.com/vishvananda/netlink"
 )
 

--- a/pkg/sriov/sriov_suite_test.go
+++ b/pkg/sriov/sriov_suite_test.go
@@ -1,7 +1,7 @@
 package sriov
 
 import (
-	"github.com/intel/sriov-cni/pkg/utils"
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
-	sriovtypes "github.com/intel/sriov-cni/pkg/types"
+	sriovtypes "github.com/k8snetworkplumbingwg/sriov-cni/pkg/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
The code and documentation  was still pointing to Intel's
repos for both srio-network-device-plugin and srio-cni.
This patch changes to to NPWG's repos.

Signed-off-by: Maxime Coquelin <maxime.coquelin@redhat.com>