### PR TITLE
Makefile: clean go mod cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
 
 script:
   - make lint
-  - sudo -E env "PATH=$PATH" make test && sudo make -E env "PATH=$PATH" clean
-  - make test && make clean
+  - sudo -E env "PATH=$PATH" make test && sudo -E env "PATH=$PATH" make clean
   - make build
   - make clean
   - make image

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,17 @@ language: go
 sudo: required
 
 go:
-  - "1.12"
+  - "1.13"
 env:
   global:
   - PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
 script:
   - make lint
-  - sudo -E env "PATH=$PATH" make test && sudo make clean
+  - sudo -E env "PATH=$PATH" make test && sudo make -E env "PATH=$PATH" clean
+  - make test && make clean
   - make build
-  - sudo -E env "PATH=$PATH" make clean 
+  - make clean
   - make image
 
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,8 @@ image: | $(BASE) ; $(info Building Docker image...)
 # Misc
 
 .PHONY: clean
-clean: ; $(info  Cleaning...)	@ ## Cleanup everything
+clean: | $(BASE) ; $(info  Cleaning...)	@ ## Cleanup everything
+	@cd $(BASE) && $(GO) clean --modcache
 	@rm -rf $(GOPATH)
 	@rm -rf $(BUILDDIR)/$(BINARY_NAME)
 	@rm -rf test/tests.* test/coverage.*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SR-IOV CNI plugin works with [SR-IOV device plugin](https://github.com/k8snetwor
 
 ## Build
 
-This plugin uses Go modules for dependency management and requires Go 1.12+ to build.
+This plugin uses Go modules for dependency management and requires Go 1.13+ to build.
 
 To build the plugin binary:
 


### PR DESCRIPTION
Files downloaded by 'go mod' are not writable (i.e: cannot be removed
with 'rm -r')

Fixes: #151 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>