### PR TITLE
Improve daemonset security

### DIFF
--- a/images/k8s-v1.10-v1.15/sriov-cni-daemonset.yaml
+++ b/images/k8s-v1.10-v1.15/sriov-cni-daemonset.yaml
@@ -14,7 +14,6 @@ spec:
         tier: node
         app: sriov-cni
     spec:
-      hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:
@@ -26,7 +25,12 @@ spec:
         image: nfvpe/sriov-cni:v2.3
         imagePullPolicy: IfNotPresent
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         resources:
           requests:
             cpu: "100m"

--- a/images/k8s-v1.16/sriov-cni-daemonset.yaml
+++ b/images/k8s-v1.16/sriov-cni-daemonset.yaml
@@ -18,7 +18,6 @@ spec:
         tier: node
         app: sriov-cni
     spec:
-      hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:
@@ -30,7 +29,12 @@ spec:
         image: nfvpe/sriov-cni:v2.3
         imagePullPolicy: IfNotPresent
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
* Make fs read-only. Mounted volume not affected.
* Drop all linux caps
* Remove needless privileged permission
* Remove needless hostnetwork permission

Signed-off-by: Martin Kennelly <martin.kennelly@intel.com>