### PR TITLE
set vlan to 0 if not defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ The below config will configure a VF using a userspace driver (uio/vfio) for use
 
 **Note** [DHCP](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp) IPAM plugin can not be used for VF bound to a dpdk driver (uio/vfio).
 
+**Note** When VLAN is not specified in the Network-Attachment-Definition, or when it is given a value of 0,
+VFs connected to this network will have no vlan tag.
+
+
 ### Advanced Configuration 
 
 SR-IOV CNI allows the setting of other SR-IOV options such as link-state and quality of service parameters. To learn more about how these parameters are set consult the [SR-IOV CNI configuration reference guide](docs/configuration-reference.md)  

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -284,17 +284,20 @@ func (s *sriovManager) ApplyVFConfig(conf *sriovtypes.NetConf) error {
 	conf.OrigVfState.FillFromVfInfo(vfState)
 
 	// 1. Set vlan
-	if conf.Vlan != nil {
-		// set vlan qos if present in the config
-		if conf.VlanQoS != nil {
-			if err = s.nLink.LinkSetVfVlanQos(pfLink, conf.VFID, *conf.Vlan, *conf.VlanQoS); err != nil {
-				return fmt.Errorf("failed to set vf %d vlan configuration: %v", conf.VFID, err)
-			}
-		} else {
-			// set vlan id field only
-			if err = s.nLink.LinkSetVfVlan(pfLink, conf.VFID, *conf.Vlan); err != nil {
-				return fmt.Errorf("failed to set vf %d vlan: %v", conf.VFID, err)
-			}
+	if conf.Vlan == nil {
+		vlan := new(int)
+		*vlan = 0
+		conf.Vlan = vlan
+	}
+	// set vlan qos if present in the config
+	if conf.VlanQoS != nil {
+		if err = s.nLink.LinkSetVfVlanQos(pfLink, conf.VFID, *conf.Vlan, *conf.VlanQoS); err != nil {
+			return fmt.Errorf("failed to set vf %d vlan configuration: %v", conf.VFID, err)
+		}
+	} else {
+		// set vlan id field only
+		if err = s.nLink.LinkSetVfVlan(pfLink, conf.VFID, *conf.Vlan); err != nil {
+			return fmt.Errorf("failed to set vf %d vlan: %v", conf.VFID, err)
 		}
 	}
 


### PR DESCRIPTION
It is more common that when no vlan tag is specified,
the interface will have no vlan at all.

The sriov-CNI acts differtly, and when a NAD is not configured with
vlan, the VF will keep it's old vlan tag. This behaviour
is not "natural" and could cause confusion.

This commit makes SRIOV-CNi treat no-valn as zero vlan,
which will effectively remove the vlan tag from the VF.

To prevent future misunderstandings a note is added tot the README
about the new behavior.

Signed-off-by: alonsadan <asadan@redhat.com>