### PR TITLE
Defer the MAC clear on the VF until after cmdDel() returns

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -185,6 +185,10 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	sm := sriov.NewSriovManager()
 
+	defer func() {
+		sm.ResetVFMacAddress(netConf)
+	}()
+
 	if !netConf.DPDKMode {
 		netns, err := ns.GetNS(args.Netns)
 		if err != nil {


### PR DESCRIPTION
This is a proposed partial fix for https://github.com/k8snetworkplumbingwg/sriov-cni/issues/126, which causes interfaces to be left in a configured state when the pause container is removed. This poses a problem specifically when bonding and MAC sharing is used, as you have the ability to create duplicate MACs if the interfaces aren't returned to their initial state when released by the CNI. This patch tries to ensure the MAC is eventually returned to its prior value.

This was written by a coworker, and I'm hoping to solicit some opinions. Is this still susceptible to the issue because the device might not always show in the init ns, or should it always be available after `cmdDel()` completes and this defer will always work? If I understand correctly there is still a small race condition, as the VF can be assigned back out from the the pool before the deferred call completes, if containers are spinning right back up.