### PR TITLE
Dont iterate on non existing VF ID

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -54,7 +54,7 @@ func GetVfid(addr string, pfName string) (int, error) {
 	if err != nil {
 		return id, err
 	}
-	for vf := 0; vf <= vfTotal; vf++ {
+	for vf := 0; vf < vfTotal; vf++ {
 		vfDir := filepath.Join(NetDirectory, pfName, "device", fmt.Sprintf("virtfn%d", vf))
 		_, err := os.Lstat(vfDir)
 		if err != nil {


### PR DESCRIPTION
VF index start from 0, totalVfs holds
the total number of VFs. loop should not
reach totalVFs value.

e.g in a system where a PF has 4 VFs
the corresponding VF indexes are: 0..3

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>