### PR TITLE
Update example daemonset images

### DIFF
--- a/images/k8s-v1.10-v1.15/sriov-cni-daemonset.yaml
+++ b/images/k8s-v1.10-v1.15/sriov-cni-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-sriov-cni
-        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.6.1
+        image: ghcr.io/k8snetworkplumbingwg/sriov-cni
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/images/k8s-v1.16/sriov-cni-daemonset.yaml
+++ b/images/k8s-v1.16/sriov-cni-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-sriov-cni
-        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.6.1
+        image: ghcr.io/k8snetworkplumbingwg/sriov-cni
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Update daemonset sriov-cni image to point to latest
We should always point to the latest image in master branch.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>