### PR TITLE
Avoid panicking in tests

### DIFF
--- a/.github/workflows/static-scan.yml
+++ b/.github/workflows/static-scan.yml
@@ -10,7 +10,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.45
           # Adding additional linters beside the default set - See https://golangci-lint.run/usage/linters
           args: --enable=golint,bodyclose,gosec,whitespace
   shellcheck:

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -8,11 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func check(e error) {
-	if e != nil {
-		panic(e)
-	}
-}
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
@@ -21,10 +16,10 @@ func TestConfig(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// create test sys tree
 	err := utils.CreateTmpSysFs()
-	check(err)
+	Expect(err).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
 	err := utils.RemoveTmpSysFs()
-	check(err)
+	Expect(err).Should(Succeed())
 })

--- a/pkg/sriov/sriov_suite_test.go
+++ b/pkg/sriov/sriov_suite_test.go
@@ -8,11 +8,6 @@ import (
 	"testing"
 )
 
-func check(e error) {
-	if e != nil {
-		panic(e)
-	}
-}
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Sriov Suite")
@@ -21,10 +16,10 @@ func TestConfig(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// create test sys tree
 	err := utils.CreateTmpSysFs()
-	check(err)
+	Expect(err).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
 	err := utils.RemoveTmpSysFs()
-	check(err)
+	Expect(err).Should(Succeed())
 })

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -13,12 +13,6 @@ import (
 	"syscall"
 )
 
-func check(e error) {
-	if e != nil {
-		panic(e)
-	}
-}
-
 type tmpSysFs struct {
 	dirRoot      string
 	dirList      []string

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -15,10 +15,10 @@ func TestUtils(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// create test sys tree
 	err := CreateTmpSysFs()
-	check(err)
+	Expect(err).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
 	err := RemoveTmpSysFs()
-	check(err)
+	Expect(err).Should(Succeed())
 })


### PR DESCRIPTION
Using Gomega assertions makes test errors more readable in most cases.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>