### PR TITLE
lint: Switch to golangci-lint

### DIFF
--- a/.github/workflows/static-scan.yml
+++ b/.github/workflows/static-scan.yml
@@ -11,8 +11,6 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.45
-          # Adding additional linters beside the default set - See https://golangci-lint.run/usage/linters
-          args: --enable=golint,bodyclose,gosec,whitespace
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters:
+  enable:
+    - revive
+    - bodyclose
+    - gosec
+    - whitespace

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ GO      = go
 GODOC   = godoc
 GOFMT   = gofmt
 TIMEOUT = 15
-V = 0
+V ?= 0
 Q = $(if $(filter 1,$V),,@)
 
 .PHONY: all
@@ -61,9 +61,9 @@ $(BUILDDIR)/$(BINARY_NAME): $(GOFILES) | $(BUILDDIR)
 
 # Tools
 
-GOLINT = $(GOBIN)/golint
-$(GOBIN)/golint: | $(BASE) ; $(info  Installing golint...)
-	$Q go install golang.org/x/lint/golint
+GOLANGCILINT = $(GOBIN)/golangci-lint
+$(GOLANGCILINT): | $(BASE) ; $(info  Installing golangci-lint...)
+	$Q go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45
 
 GOCOVMERGE = $(GOBIN)/gocovmerge
 $(GOBIN)/gocovmerge: | $(BASE) ; $(info  Installing gocovmerge...)
@@ -121,10 +121,8 @@ test-coverage: fmt lint test-coverage-tools | $(BASE) ; $(info  Running coverage
 	$Q $(GOCOV) convert $(COVERAGE_PROFILE) | $(GOCOVXML) > $(COVERAGE_XML)
 
 .PHONY: lint
-lint: | $(BASE) $(GOLINT) ; $(info  Running golint...) @ ## Run golint on all source files
-	$Q cd $(BASE) && ret=0 && for pkg in $(PKGS); do \
-		test -z "$$($(GOLINT) $$pkg | tee /dev/stderr)" || ret=1 ; \
-	 done ; exit $$ret
+lint: | $(BASE) $(GOLANGCILINT) ; $(info  Running golangci-lint...) @ ## Run golint on all source files
+	$Q $(GOLANGCILINT) run ./...
 
 .PHONY: fmt
 fmt: ; $(info  Running gofmt...) @ ## Run gofmt on all source files


### PR DESCRIPTION
This PR comes from [this thread on #205](https://github.com/k8snetworkplumbingwg/sriov-cni/pull/205#discussion_r908494949)

`golint` has been deprecated and this PR replaces it with `golangci-lint`, in order to have the same lint output as CI.

Also, it replace `golint` sublinter with `revive`, as suggested by [golangci-lint in its output](https://github.com/k8snetworkplumbingwg/sriov-cni/runs/7095092180?check_suite_focus=true)

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.45.2-linux-amd64/golangci-lint run --out-format=github-actions --enable=golint,bodyclose,gosec,whitespace] in [] ...
  level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."
```