### PR TITLE
Do not try to set VF MAC non-administratively

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -313,4 +314,17 @@ func IsIPv4(ip net.IP) bool {
 // IsIPv6 checks if a net.IP is an IPv6 address.
 func IsIPv6(ip net.IP) bool {
 	return ip.To4() == nil && ip.To16() != nil
+}
+
+// Retry retries a given function until no return error; times out after retries*sleep
+func Retry(retries int, sleep time.Duration, f func() error) error {
+	err := error(nil)
+	for retry := 0; retry < retries; retry++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(sleep)
+	}
+	return err
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"errors"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -76,6 +79,16 @@ var _ = Describe("Utils", func() {
 		It("Assuming not existing vf", func() {
 			_, err := GetVFLinkNamesFromVFID("enp175s0f1", 3)
 			Expect(err).To(HaveOccurred(), "Not existing VF should return an error")
+		})
+	})
+	Context("Checking Retry functon", func() {
+		It("Assuming calling function fails", func() {
+			err := Retry(5, 10*time.Millisecond, func() error { return errors.New("") })
+			Expect(err).To((HaveOccurred()), "Retry should return an error")
+		})
+		It("Assuming calling function does not fail", func() {
+			err := Retry(5, 10*time.Millisecond, func() error { return nil })
+			Expect(err).NotTo((HaveOccurred()), "Retry should not return an error")
 		})
 	})
 })


### PR DESCRIPTION
The VF MAC address is, when requested, already set administratively via PF and works regardless whether VF trust is on or off.

Trying to set VF MAC address non-administratively without trust on is expected to gracefully fail. For example, here's the dmesg output example:

  kernel: i40e 0000:3b:00.0: VF attempting to override administratively set MAC address, bring down and up the VF interface to resume normal operation
  kernel: i40e 0000:3b:00.0: VF 0 failed opcode 10, retval: -1
  kernel: iavf 0000:3b:02.0: Failed to add MAC filter, error IAVF_ERR_NVM

The same applies also when releasing the VF.

Tested on Intel XXV710 (i40e/iavf), Intel E810 (ice/iavf) and Mellanox ConnectX-4 (mlx5_core).

Signed-off-by: Carlos Goncalves <cgoncalves@redhat.com>