### PR TITLE
support build image for arm64 and ppc64le

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -6,15 +6,16 @@ on:
     schedule:
       - cron: "0 8 * * 0" # every sunday
 jobs:
-  build:
+  build-test:
     strategy:
       matrix:
         go-version: [1.19.x]
         os: [ubuntu-latest]
+        goos: [linux]
+        goarch: [amd64, arm64, ppc64le]
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: on
-      TARGET: amd64
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -24,15 +25,19 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Build
+      - name: Build test for ${{ matrix.goarch }}
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          GOOS: ${{ matrix.goos }}
         run: GOARCH="${TARGET}" go build ./cmd/sriov/...
 
       - name: Go test
+        if: ${{ matrix.goarch }} == "amd64"
         run: sudo go test ./... # sudo needed for netns change in test
 
   coverage:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-test
     name: coverage
     steps:
       - name: Set up Go

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -1,13 +1,16 @@
 name: "Push images on merge to master"
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
 on:
   push:
     branches:
       - master
 jobs:
-  build-and-push-image-sriov-cni:
+  build-and-push-amd64-sriov-cni:
+    name: Image Push AMD64
     runs-on: ubuntu-20.04
-    env:
-      IMAGE_NAME: ghcr.io/${{ github.repository }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -27,7 +30,97 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64
           tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest-amd64
+            ${{ steps.docker_meta.outputs.tags }}:${{ github.sha }}
           file: ./Dockerfile
+
+  build-and-push-arm64-sriov-cni:
+    name: Image Push ARM64
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sriov-cni
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest-arm64
+          file: ./Dockerfile.arm64
+
+  build-and-push-ppc64le-sriov-cni:
+    name: Image Push ppc64le
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sriov-cni
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          platforms: linux/ppc64le
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest-ppc64le
+          file: ./Dockerfile.ppc64le
+
+  push-manifest:
+    runs-on: ubuntu-20.04
+    needs: [build-and-push-amd64-sriov-cni,build-and-push-amr64-sriov-cni,build-and-push-ppc64le-sriov-cni]
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create manifest for multi-arch images
+      run: |
+        # pull
+        docker pull ${{ env.IMAGE_NAME }}:latest-amd64
+        docker pull ${{ env.IMAGE_NAME }}:latest-arm64
+        docker pull ${{ env.IMAGE_NAME }}:latest-ppc64le
+        # create
+        docker manifest create ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:latest-amd64 ${{ env.IMAGE_NAME }}:latest-arm64 ${{ env.IMAGE_NAME }}:latest-ppc64le
+        # annotate
+        docker manifest annotate ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:latest-amd64 --arch amd64
+        docker manifest annotate ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:latest-arm64 --arch arm64
+        docker manifest annotate ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:latest-ppc64le --arch ppc64le
+        # push
+        docker manifest push ${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,13 +1,16 @@
 name: "Push images on release"
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
 on:
   push:
     tags:
       - v*
 jobs:
-  build-and-push-image-sriov-cni:
+  build-and-push-amd64-sriov-cni:
     runs-on: ubuntu-20.04
-    env:
-      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    name: Image push AMD64
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -34,6 +37,112 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64
           tags: |
-            ${{ steps.docker_meta.outputs.tags }}
+            ${{ steps.docker_meta.outputs.tags }}-amd64
+            ${{ steps.docker_meta.outputs.tags }}:${{ github.sha }}
           file: ./Dockerfile
+
+  build-and-push-arm64-sriov-cni:
+    runs-on: ubuntu-20.04
+    name: Image push ARM64
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tag-latest: false
+
+      - name: Build and push sriov-cni
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}-arm64
+          file: ./Dockerfile.arm64
+
+  build-and-push-ppc64le-sriov-cni:
+    runs-on: ubuntu-20.04
+    name: Image push ppc64le
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tag-latest: false
+
+      - name: Build and push sriov-cni
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}-ppc64le
+          file: ./Dockerfile.ppc64le
+
+  push-manifest:
+    runs-on: ubuntu-20.04
+    needs: [build-and-push-amd64-sriov-cni,build-and-push-amr64-sriov-cni,build-and-push-ppc64le-sriov-cni]
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Docker meta
+      id: docker_meta
+      uses: crazy-max/ghaction-docker-meta@v1
+      with:
+        images: ${{ env.IMAGE_NAME }}
+        tag-latest: false
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create manifest for multi-arch images
+      run: |
+        # pull
+        docker pull ${{ steps.docker_meta.outputs.tags }}-amd64
+        docker pull ${{ steps.docker_meta.outputs.tags }}-arm64
+        docker pull ${{ steps.docker_meta.outputs.tags }}-ppc64le
+        # create
+        docker manifest create ${{ steps.docker_meta.outputs.tags }} ${{ steps.docker_meta.outputs.tags }}-amd64 ${{ steps.docker_meta.outputs.tags }}-arm64 ${{ steps.docker_meta.outputs.tags }}-ppc64le
+        # annotate
+        docker manifest annotate ${{ steps.docker_meta.outputs.tags }} ${{ steps.docker_meta.outputs.tags }}-amd64 --arch amd64
+        docker manifest annotate ${{ steps.docker_meta.outputs.tags }} ${{ steps.docker_meta.outputs.tags }}-arm64 --arch arm64
+        docker manifest annotate ${{ steps.docker_meta.outputs.tags }} ${{ steps.docker_meta.outputs.tags }}-ppc64le --arch ppc64le
+        # push
+        docker manifest push ${{ steps.docker_meta.outputs.tags }}

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,21 @@
+FROM arm64v8/golang:alpine as builder
+
+COPY . /usr/src/sriov-cni
+
+ENV HTTP_PROXY $http_proxy
+ENV HTTPS_PROXY $https_proxy
+
+WORKDIR /usr/src/sriov-cni
+RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 && \
+    make clean && \
+    make build
+
+FROM arm64v8/alpine
+COPY --from=builder /usr/src/sriov-cni/build/sriov /usr/bin/
+WORKDIR /
+
+LABEL io.k8s.display-name="SR-IOV CNI"
+
+COPY ./images/entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,21 @@
+FROM ppc64le/golang:alpine as builder
+
+COPY . /usr/src/sriov-cni
+
+ENV HTTP_PROXY $http_proxy
+ENV HTTPS_PROXY $https_proxy
+
+WORKDIR /usr/src/sriov-cni
+RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 && \
+    make clean && \
+    make build
+
+FROM ppc64le/alpine
+COPY --from=builder /usr/src/sriov-cni/build/sriov /usr/bin/
+WORKDIR /
+
+LABEL io.k8s.display-name="SR-IOV CNI"
+
+COPY ./images/entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -16,8 +16,8 @@ usage()
     printf "\n"
     printf "./entrypoint.sh\n"
     printf "\t-h --help\n"
-    printf "\t--cni-bin-dir=%s\n" $CNI_BIN_DIR
-    printf "\t--sriov-bin-file=%s\n" $SRIOV_BIN_FILE
+    printf "\t--cni-bin-dir=%s\n" "$CNI_BIN_DIR"
+    printf "\t--sriov-bin-file=%s\n" "$SRIOV_BIN_FILE"
 }
 
 # Parse parameters given as arguments to this script.


### PR DESCRIPTION
support build image for arm64 and ppc64le

ATM, `sriov-cni` only for amd64, This PR supports building images for both `arm64` and `ppc64le` architectures in the workflow file for building images.

Signed-off-by: cyclinder <qifeng.guo@daocloud.io>