### PR TITLE
add vf orig mac as default

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -78,10 +78,16 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("SRIOV-CNI failed to configure VF %q", err)
 	}
 
+	macAddr = netConf.OrigVfState.AdminMAC
+	if netConf.MAC != "" {
+		macAddr = netConf.MAC
+	}
+
 	result := &current.Result{}
 	result.Interfaces = []*current.Interface{{
 		Name:    args.IfName,
 		Sandbox: netns.Path(),
+		Mac:     macAddr,
 	}}
 
 	if !netConf.DPDKMode {


### PR DESCRIPTION
I use SR-IOV device plugin to allocate VFs, and get VF mac address from pod annotations `k8s.v1.cni.cncf.io/network-status`. 
Howerver, mac address record does not exist when VFIO as VFs backed.

Mac address is nil while DPDKMode is true.
```
	if !netConf.DPDKMode {
                ...
		result.Interfaces[0].Mac = macAddr
	}
```



Maybe assign `netConf.OrigVfState.AdminMAC` to  `result.Interfaces[0].Mac` as default is better.