### PR TITLE
code clean for pkg/utils.go IsValidMACAddress

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -300,6 +300,7 @@ func IsValidMACAddress(addr net.HardwareAddr) bool {
 		for _, invalidMACAddress := range invalidMACAddresses {
 			if bytes.Equal(addr, invalidMACAddress) {
 				valid = false
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup


```
for _, invalidMACAddress := range invalidMACAddresses {
			if bytes.Equal(addr, invalidMACAddress) {
				valid = false
				break
			}
		}
```
the code will reduce the loop cost , when it is first found to be false . just break and skip next process.


And 
```
if err != nil || linkObj.Attrs() == nil {
		return fmt.Errorf("failed to get netlink device with name %q: %v", ifName, err)
	}
```
will fix the potential panic, when linkObj.Attrs() is nil..
