### PR TITLE
Add both hardware and nic mac allocation retry

### DIFF
--- a/pkg/sriov/sriov_suite_test.go
+++ b/pkg/sriov/sriov_suite_test.go
@@ -1,11 +1,12 @@
 package sriov
 
 import (
-	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"testing"
+
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 )
 
 func TestConfig(t *testing.T) {

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/vishvananda/netlink"
 )
 
 type tmpSysFs struct {
@@ -134,4 +136,21 @@ func RemoveTmpSysFs() error {
 	}
 
 	return os.RemoveAll(ts.dirRoot)
+}
+
+// FakeLink is a dummy netlink struct used during testing
+type FakeLink struct {
+	netlink.LinkAttrs
+}
+
+// type FakeLink struct {
+// 	linkAtrrs *netlink.LinkAttrs
+// }
+
+func (l *FakeLink) Attrs() *netlink.LinkAttrs {
+	return &l.LinkAttrs
+}
+
+func (l *FakeLink) Type() string {
+	return "FakeLink"
 }


### PR DESCRIPTION
This commit add a retry function for all the mac address allocation functions.

this is needed because some of the drivers have async mac allocation or get a device or resouce busy errors until the vf device is fully configured on the system so instead of failing the CNI we just wait 100 miliseconds


Signed-off-by: Sebastian Sch <sebassch@gmail.com>