### PR TITLE
expose mac address as part of networks-status in pod yaml

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -42,7 +42,6 @@ func getEnvArgs(envArgsString string) (*envArgs, error) {
 }
 
 func cmdAdd(args *skel.CmdArgs) error {
-	var macAddr string
 	netConf, err := config.LoadConf(args.StdinData)
 	if err != nil {
 		return fmt.Errorf("SRIOV-CNI failed to load netconf: %v", err)
@@ -102,13 +101,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}}
 
 	if !netConf.DPDKMode {
-		macAddr, err = sm.SetupVF(netConf, args.IfName, netns)
+		err = sm.SetupVF(netConf, args.IfName, netns)
 
 		if err != nil {
 			return fmt.Errorf("failed to set up pod interface %q from the device %q: %v", args.IfName, netConf.Master, err)
 		}
-		result.Interfaces[0].Mac = macAddr
 	}
+
+	result.Interfaces[0].Mac = config.GetMacAddressForResult(netConf)
 
 	// run the IPAM plugin
 	if netConf.IPAM.Type != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,3 +155,21 @@ func LoadConfFromCache(args *skel.CmdArgs) (*sriovtypes.NetConf, string, error) 
 
 	return netConf, cRefPath, nil
 }
+
+// GetMacAddressForResult return the mac address we should report to the CNI call return object
+// if the device is on kernel mode we report that one back
+// if not we check the administrative mac address on the PF
+// if it is set and is not zero, report it.
+func GetMacAddressForResult(netConf *sriovtypes.NetConf) string {
+	if netConf.MAC != "" {
+		return netConf.MAC
+	}
+	if !netConf.DPDKMode {
+		return netConf.OrigVfState.EffectiveMAC
+	}
+	if netConf.OrigVfState.AdminMAC != "00:00:00:00:00:00" {
+		return netConf.OrigVfState.AdminMAC
+	}
+
+	return ""
+}

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -73,9 +73,9 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkSetVfVlanQos", mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return(nil)
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
 			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
-			macAddr, err := sm.SetupVF(netconf, podifName, targetNetNS)
+			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(macAddr).To(Equal("6e:16:06:0e:b7:e9"))
+			Expect(netconf.OrigVfState.EffectiveMAC).To(Equal("6e:16:06:0e:b7:e9"))
 		})
 		It("Setting VF's MAC address", func() {
 			var targetNetNS ns.NetNS
@@ -116,9 +116,8 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkSetUp", fakeLink).Return(nil)
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
 			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
-			macAddr, err := sm.SetupVF(netconf, podifName, targetNetNS)
+			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(macAddr).To(Equal(netconf.MAC))
 			mocked.AssertExpectations(t)
 		})
 
@@ -153,7 +152,7 @@ var _ = Describe("Sriov", func() {
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
 
 			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
-			_, err = sm.SetupVF(netconf, podifName, targetNetNS)
+			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
 		},
 			Entry("Enabling all multicast", "on", "LinkSetAllmulticastOn"),

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -36,7 +36,7 @@ func (vs *VfState) FillFromVfInfo(info *netlink.VfInfo) {
 type NetConf struct {
 	types.NetConf
 	OrigVfState   VfState // Stores the original VF state as it was prior to any operations done during cmdAdd flow
-	DPDKMode      bool
+	DPDKMode      bool    `json:"-"`
 	Master        string
 	MAC           string
 	Vlan          *int   `json:"vlan"`


### PR DESCRIPTION
this commit passes the mac address in the cni result.

this will also work in case the vf uses a user-space driver like vfio as we have the mac address for it from the PF

Signed-off-by: Sebastian Sch <sebassch@gmail.com>