### PR TITLE
Bump golangci-lint in Makefile as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ $(BUILDDIR)/$(BINARY_NAME): $(GOFILES) | $(BUILDDIR)
 
 GOLANGCILINT = $(GOBIN)/golangci-lint
 $(GOLANGCILINT): | $(BASE) ; $(info  Installing golangci-lint...)
-	$Q go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45
+	$Q go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
 GOCOVMERGE = $(GOBIN)/gocovmerge
 $(GOCOVMERGE): | $(BASE) ; $(info  Building gocovmerge...)


### PR DESCRIPTION
make didn't work without it. Please keep golangci-lint version consistent in .github/workflows/static-scan.yml and in Makefile