### PR TITLE
Enable race detection in unit tests

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Go test
         if: ${{ matrix.goarch }} == "amd64"
-        run: sudo go test ./... # sudo needed for netns change in test
+        run: sudo go test -race ./... # sudo needed for netns change in test
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request enables race detection in unit tests by modifying the Go test step in buildtest.yml. The test configuration is updated to include the '-race' flag, allowing thorough race detection during testing. 

Race detection can help identifying potential data race conditions, which can lead to hard-to-debug issues in concurrent code. By enabling race detection in our unit tests, we can detect and address these race conditions, ensuring the reliability and stability of our code. (for further reference view: https://go.dev/doc/articles/race_detector)