### PR TITLE
Delete ConfIFNames parameter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,8 +51,8 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 	}
 
 	// Assuming VF is netdev interface; Get interface name(s)
-	hostIFNames, err := utils.GetVFLinkNames(n.DeviceID)
-	if err != nil || hostIFNames == "" {
+	hostIFName, err := utils.GetVFLinkName(n.DeviceID)
+	if err != nil || hostIFName == "" {
 		// VF interface not found; check if VF has dpdk driver
 		hasDpdkDriver, err := utils.HasDpdkDriver(n.DeviceID)
 		if err != nil {
@@ -61,11 +61,11 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 		n.DPDKMode = hasDpdkDriver
 	}
 
-	if hostIFNames != "" {
-		n.OrigVfState.HostIFName = hostIFNames
+	if hostIFName != "" {
+		n.OrigVfState.HostIFName = hostIFName
 	}
 
-	if hostIFNames == "" && !n.DPDKMode {
+	if hostIFName == "" && !n.DPDKMode {
 		return nil, fmt.Errorf("LoadConf(): the VF %s does not have a interface name or a dpdk driver", n.DeviceID)
 	}
 

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -115,7 +115,6 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, netns
 	}); err != nil {
 		return "", fmt.Errorf("error setting up interface in container namespace: %q", err)
 	}
-	conf.ContIFNames = podifName
 
 	return macAddress, nil
 }
@@ -125,10 +124,6 @@ func (s *sriovManager) ReleaseVF(conf *sriovtypes.NetConf, podifName string, net
 	initns, err := ns.GetCurrentNS()
 	if err != nil {
 		return fmt.Errorf("failed to get init netns: %v", err)
-	}
-
-	if len(conf.ContIFNames) < 1 && len(conf.ContIFNames) != len(conf.OrigVfState.HostIFName) {
-		return fmt.Errorf("number of interface names mismatch ContIFNames: %d HostIFNames: %d", len(conf.ContIFNames), len(conf.OrigVfState.HostIFName))
 	}
 
 	return netns.Do(func(_ ns.NetNS) error {

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -32,10 +32,9 @@ var _ = Describe("Sriov", func() {
 		BeforeEach(func() {
 			podifName = "net1"
 			netconf = &sriovtypes.NetConf{
-				Master:      "enp175s0f1",
-				DeviceID:    "0000:af:06.0",
-				VFID:        0,
-				ContIFNames: "net1",
+				Master:   "enp175s0f1",
+				DeviceID: "0000:af:06.0",
+				VFID:     0,
 				OrigVfState: sriovtypes.VfState{
 					HostIFName: "enp175s6",
 				},
@@ -132,10 +131,9 @@ var _ = Describe("Sriov", func() {
 		BeforeEach(func() {
 			podifName = "net1"
 			netconf = &sriovtypes.NetConf{
-				Master:      "enp175s0f1",
-				DeviceID:    "0000:af:06.0",
-				VFID:        0,
-				ContIFNames: "net1",
+				Master:   "enp175s0f1",
+				DeviceID: "0000:af:06.0",
+				VFID:     0,
 				OrigVfState: sriovtypes.VfState{
 					HostIFName:   "enp175s6",
 					EffectiveMAC: "6e:16:06:0e:b7:e9",
@@ -157,7 +155,7 @@ var _ = Describe("Sriov", func() {
 
 			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink", HardwareAddr: fakeMac}}
 
-			mocked.On("LinkByName", netconf.ContIFNames).Return(fakeLink, nil)
+			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
@@ -176,10 +174,9 @@ var _ = Describe("Sriov", func() {
 		BeforeEach(func() {
 			podifName = "net1"
 			netconf = &sriovtypes.NetConf{
-				Master:      "enp175s0f1",
-				DeviceID:    "0000:af:06.0",
-				VFID:        0,
-				ContIFNames: "net1",
+				Master:   "enp175s0f1",
+				DeviceID: "0000:af:06.0",
+				VFID:     0,
 				OrigVfState: sriovtypes.VfState{
 					HostIFName:   "enp175s6",
 					EffectiveMAC: "c6:c8:7f:1f:21:90",
@@ -198,7 +195,7 @@ var _ = Describe("Sriov", func() {
 			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
 			mocked := &mocks_utils.NetlinkManager{}
 
-			mocked.On("LinkByName", netconf.ContIFNames).Return(fakeLink, nil)
+			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
@@ -229,7 +226,7 @@ var _ = Describe("Sriov", func() {
 				HardwareAddr: fakeMac,
 			}}
 
-			mocked.On("LinkByName", netconf.ContIFNames).Return(fakeLink, nil)
+			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
 			mocked.On("LinkByName", netconf.OrigVfState.HostIFName).Return(tempLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetHardwareAddr", tempLink, fakeMac).Return(nil)
@@ -248,10 +245,9 @@ var _ = Describe("Sriov", func() {
 
 		BeforeEach(func() {
 			netconf = &sriovtypes.NetConf{
-				Master:      "enp175s0f1",
-				DeviceID:    "0000:af:06.0",
-				VFID:        0,
-				ContIFNames: "net1",
+				Master:   "enp175s0f1",
+				DeviceID: "0000:af:06.0",
+				VFID:     0,
 				OrigVfState: sriovtypes.VfState{
 					HostIFName: "enp175s6",
 				},
@@ -288,10 +284,9 @@ var _ = Describe("Sriov", func() {
 
 		BeforeEach(func() {
 			netconf = &sriovtypes.NetConf{
-				Master:      "enp175s0f1",
-				DeviceID:    "0000:af:06.0",
-				VFID:        0,
-				ContIFNames: "net1",
+				Master:   "enp175s0f1",
+				DeviceID: "0000:af:06.0",
+				VFID:     0,
 				OrigVfState: sriovtypes.VfState{
 					HostIFName: "enp175s6",
 				},
@@ -320,18 +315,17 @@ var _ = Describe("Sriov", func() {
 			minTxRate := 1000
 
 			netconf = &sriovtypes.NetConf{
-				Master:      "enp175s0f1",
-				DeviceID:    "0000:af:06.0",
-				VFID:        0,
-				ContIFNames: "net1",
-				MAC:         "d2:fc:22:a7:0d:e8",
-				Vlan:        &vlan,
-				VlanQoS:     &vlanQos,
-				SpoofChk:    "on",
-				MaxTxRate:   &maxTxRate,
-				MinTxRate:   &minTxRate,
-				Trust:       "on",
-				LinkState:   "enable",
+				Master:    "enp175s0f1",
+				DeviceID:  "0000:af:06.0",
+				VFID:      0,
+				MAC:       "d2:fc:22:a7:0d:e8",
+				Vlan:      &vlan,
+				VlanQoS:   &vlanQos,
+				SpoofChk:  "on",
+				MaxTxRate: &maxTxRate,
+				MinTxRate: &minTxRate,
+				Trust:     "on",
+				LinkState: "enable",
 				OrigVfState: sriovtypes.VfState{
 					HostIFName:   "enp175s6",
 					SpoofChk:     false,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,7 +42,6 @@ type NetConf struct {
 	VlanQoS       *int   `json:"vlanQoS"`
 	DeviceID      string `json:"deviceID"` // PCI address of a VF in valid sysfs format
 	VFID          int
-	ContIFNames   string // VF names after in the container; used during deletion
 	MinTxRate     *int   `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
 	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
 	SpoofChk      string `json:"spoofchk,omitempty"`   // on|off

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -170,8 +170,8 @@ func GetSharedPF(ifName string) (string, error) {
 	return pfName, fmt.Errorf("Shared PF not found")
 }
 
-// GetVFLinkNames returns VF's network interface name given it's PCI addr
-func GetVFLinkNames(pciAddr string) (string, error) {
+// GetVFLinkName returns VF's network interface name given it's PCI addr
+func GetVFLinkName(pciAddr string) (string, error) {
 	var names []string
 	vfDir := filepath.Join(SysBusPci, pciAddr, "net")
 	if _, err := os.Lstat(vfDir); err != nil {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Utils", func() {
 		// 	Expect(err).To(HaveOccurred(), "Looking for shared PF for not supported NIC should return an error")
 		// })
 	})
-	Context("Checking GetVFLinkNames function", func() {
+	Context("Checking GetVFLinkName function", func() {
 		It("Assuming existing vf", func() {
 			result, err := GetVFLinkNamesFromVFID("enp175s0f1", 0)
 			Expect(result).To(ContainElement("enp175s6"), "Existing PF should have at least one VF")


### PR DESCRIPTION
This parameter is only used in a check that is not valid because only a single interface name is used by the plugin. Additionally, the func GetVFLinkNames was renamed to GetVFLinkName to reflect that a single name is returned.