### PR TITLE
Check VF ID existence in Del cmd

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -219,6 +219,11 @@ func cmdDel(args *skel.CmdArgs) error {
 		return nil
 	}
 
+	// Verify VF ID existence.
+	if _, err := utils.GetVfid(netConf.DeviceID, netConf.Master); err != nil {
+		return fmt.Errorf("cmdDel() error obtaining VF ID: %q", err)
+	}
+
 	sm := sriov.NewSriovManager()
 
 	/* ResetVFConfig resets a VF administratively. We must run ResetVFConfig


### PR DESCRIPTION
This checks if the VF is still present in the node when the Del command is executed.

Fixes #271