### PR TITLE
Move allocated pci deletion in defer of del cmd

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -208,6 +208,9 @@ func cmdDel(args *skel.CmdArgs) error {
 	defer func() {
 		if err == nil && cRefPath != "" {
 			_ = utils.CleanCachedNetConf(cRefPath)
+
+			allocator := utils.NewPCIAllocator(config.DefaultCNIDir)
+			_ = allocator.DeleteAllocatedPCI(netConf.DeviceID)
 		}
 	}()
 
@@ -258,12 +261,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		if err = sm.ReleaseVF(netConf, args.IfName, netns); err != nil {
 			return err
 		}
-	}
-
-	// Mark the pci address as released
-	allocator := utils.NewPCIAllocator(config.DefaultCNIDir)
-	if err = allocator.DeleteAllocatedPCI(netConf.DeviceID); err != nil {
-		return fmt.Errorf("error cleaning the pci allocation for vf pci address %s: %v", netConf.DeviceID, err)
 	}
 
 	return nil


### PR DESCRIPTION
The allocated pci is supposed to be deleted when the del command is completed. However, placing this logic at the end of the function does not always guaranteed its execution. For instance, if ResetVfConfig or ReleaseVF fail, the err variable is overwritten which causes the cache to be deleted in the defer function and the next del retry to exit without deleting the allocated pci.
By placing this logic along the deletion of the cache will ensure that all operations in the del command are done.