### PR TITLE
chore: Add OWNERS file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ Temporary Items
 # Local History for Visual Studio Code
 .history/
 
+### IntelliJ ###
+.idea
+
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 .history

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+## ADMINS: People who control settings for the repo.
+adrianchiris
+dougbtv
+
+## Maintainers: People who can merge code in this repo.
+zeeke
+SchSeba
+Eoghan1232


### PR DESCRIPTION
Add an OWNERS file to the SR-IOV CNI project. This OWNERS file will be reflected into the github permissions for this project once merged.

## Context
This proposed OWNERS file comes from discussion around the way the NPWG handles project roles which took place in recent community meetings.

A governance doc defining project roles and process is pending approval at  https://github.com/k8snetworkplumbingwg/community/pull/23 This change was discussed in the NPWG community meetings on [Feb. 8th](https://docs.google.com/document/d/1oE93V3SgOGWJ4O1zeD1UmpeToa0ZiiO6LqRAmZBPFWM/edit#heading=h.3hj4tertx9nj) and [Feb 22nd](https://docs.google.com/document/d/1oE93V3SgOGWJ4O1zeD1UmpeToa0ZiiO6LqRAmZBPFWM/edit#heading=h.5cn4jef8loy1). 

## Changes
Currently SR-IOV CNI has the following owners:
```
hustcat read
zeeke maintain
SchSeba admin
zshi-redhat write
martinkennelly maintain
eoghanlawless maintain
ahalimx86 maintain
Eoghan1232 maintain
killianmuldoon admin
michaeloreillyintel maintain
```

After merging this PR this would be changed to:
```
adrianchiris admin
dougbtv admin
zeeke maintain
SchSeba maintain
Eoghan1232 maintain
```
