### PR TITLE
Update configuration-reference.md in SRIOV DPDK config

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -29,7 +29,7 @@ An SR-IOV CNI config with each field filled out looks like:
 {
     "cniVersion": "0.3.1",
     "name": "sriov-dpdk",
-    "type": "sriovi-net",
+    "type": "sriov",
     "deviceID": "0000:03:02.0",
     "mac": "CA:FE:C0:FF:EE:00",
     "vlan": 1000,


### PR DESCRIPTION
Taking a look of the example, looks like the code block is referring to an old name of the plugin.

Even in the doc file, in line 8 appears the correct type: 

* `type` (string, required): "sriov"

