### PR TITLE
Fix Gratuitous ARPs critical error on ipv6

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -212,7 +212,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			hasCarrier := utils.WaitForCarrier(args.IfName, 200*time.Millisecond)
 
 			/* The error is ignored here because enabling this feature is only a performance enhancement. */
-			err = utils.AnnounceIPs(args.IfName, result.IPs)
+			err := utils.AnnounceIPs(args.IfName, result.IPs)
 
 			logging.Debug("announcing IPs", "hasCarrier", hasCarrier, "IPs", result.IPs, "announceError", err)
 			return nil


### PR DESCRIPTION
In the case where the Gratuitous ARPs send function failed we failed the all CNI create and revert the configuration