### PR TITLE
Retry Sendto() for IPv6 NA for tentative IPv6 addresses and EADDRNOTAVAIL

### DIFF
--- a/pkg/sriov/mocks/pci_utils_mock.go
+++ b/pkg/sriov/mocks/pci_utils_mock.go
@@ -23,6 +23,20 @@ func (_m *PciUtils) EnableArpAndNdiscNotify(ifName string) error {
 	return r0
 }
 
+// EnableOptimisticDad provides a mock function with given fields: ifName
+func (_m *PciUtils) EnableOptimisticDad(ifName string) error {
+	ret := _m.Called(ifName)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(ifName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetPciAddress provides a mock function with given fields: ifName, vf
 func (_m *PciUtils) GetPciAddress(ifName string, vf int) (string, error) {
 	ret := _m.Called(ifName, vf)

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -16,6 +16,7 @@ type pciUtils interface {
 	GetVFLinkNamesFromVFID(pfName string, vfID int) ([]string, error)
 	GetPciAddress(ifName string, vf int) (string, error)
 	EnableArpAndNdiscNotify(ifName string) error
+	EnableOptimisticDad(ifName string) error
 }
 
 type pciUtilsImpl struct{}
@@ -34,6 +35,10 @@ func (p *pciUtilsImpl) GetPciAddress(ifName string, vf int) (string, error) {
 
 func (p *pciUtilsImpl) EnableArpAndNdiscNotify(ifName string) error {
 	return utils.EnableArpAndNdiscNotify(ifName)
+}
+
+func (p *pciUtilsImpl) EnableOptimisticDad(ifName string) error {
+	return utils.EnableOptimisticDad(ifName)
 }
 
 // Manager provides interface invoke sriov nic related operations
@@ -147,8 +152,12 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, netns
 			}
 		}
 
-		// 8. Bring IF up in Pod netns
-		logging.Debug("8. Bring IF up in Pod netns",
+		logging.Debug("8. Enable Optimistic DAD for IPv6 addresses", "func", "SetupVF",
+			"linkObj", linkObj)
+		_ = s.utils.EnableOptimisticDad(podifName)
+
+		// 9. Bring IF up in Pod netns
+		logging.Debug("9. Bring IF up in Pod netns",
 			"func", "SetupVF",
 			"linkObj", linkObj)
 		if err := s.nLink.LinkSetUp(linkObj); err != nil {

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkSetUp", fakeLink).Return(nil)
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
+			mockedPciUtils.On("EnableOptimisticDad", mock.AnythingOfType("string")).Return(nil)
 			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
 			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
@@ -121,6 +122,7 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkSetNsFd", net2Link, mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkSetUp", net2Link).Return(nil)
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
+			mockedPciUtils.On("EnableOptimisticDad", mock.AnythingOfType("string")).Return(nil)
 			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
 			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
@@ -174,6 +176,7 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkSetNsFd", net2Link, mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkSetUp", net2Link).Return(nil)
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
+			mockedPciUtils.On("EnableOptimisticDad", mock.AnythingOfType("string")).Return(nil)
 			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
 			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
@@ -228,6 +231,7 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkSetNsFd", net2Link, mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkSetUp", net2Link).Return(nil)
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
+			mockedPciUtils.On("EnableOptimisticDad", mock.AnythingOfType("string")).Return(nil)
 			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
 			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -51,6 +51,16 @@ func EnableArpAndNdiscNotify(ifName string) error {
 	return nil
 }
 
+// EnableOptimisticDad enables IPv6 /proc/sys/net/ipv6/conf/$ifName/optimistic_dad
+func EnableOptimisticDad(ifName string) error {
+	path := filepath.Join(SysV6NdiscNotify, ifName, "optimistic_dad")
+	err := os.WriteFile(path, []byte("1"), os.ModeAppend)
+	if err != nil {
+		return fmt.Errorf("failed to write optimistic_dad=1 for interface %s: %v", ifName, err)
+	}
+	return nil
+}
+
 // GetSriovNumVfs takes in a PF name(ifName) as string and returns number of VF configured as int
 func GetSriovNumVfs(ifName string) (int, error) {
 	var vfTotal int


### PR DESCRIPTION
When kernel initially adds an IPv6 address, it is still tentative and
pending DuplicateAddressDetection. Trying to use the address results in
EADDRNOTAVAIL error.

Detect that error, and retry for up to 3 seconds to send the message.

Unfortunately, DAD can easily take more than a second, so this change
delays the completion of the CNI binary quite a bit.

---

@SchSeba  Follow-up for https://github.com/k8snetworkplumbingwg/sriov-cni/pull/306

This seems to happen with Openshift 4.17, which makes me wonder whether previous versions had ~opportunistic~optimistic DAD enabled. If so, why was it disabled?