### PR TITLE
Makefile: dont't run "test" as part of default "all" make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ V ?= 0
 Q = $(if $(filter 1,$V),,@)
 
 .PHONY: all
-all: fmt lint build test
+all: fmt lint build
 
 $(BINDIR) $(BUILDDIR) $(COVERAGE_DIR): ; $(info Creating directory $@...)
 	@mkdir -p $@


### PR DESCRIPTION
The unit tests require CAP_NET_ADMIN permissions, so commonly they fail in a developer environment for valid reasons.

Having the "test" target part of the default make target ("all") will fail in such an environment, which is inconvenient.

Running unit tests should be a separate make target. To run tests, explicitly run `make test`.

Fixes: f2dbb73a9938 ('Makefile refactor')

---

Follow-up to https://github.com/k8snetworkplumbingwg/sriov-cni/pull/305#issuecomment-2259950853