### PR TITLE
Avoid resetting the VF if the netns does not exist 

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           LOCAL_SRIOV_CNI_IMAGE: ghaction-sriov-cni:pr-${{github.event.pull_request.number}}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ env.TEST_REPORT_PATH }}

--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -245,6 +245,17 @@ func cmdDel(args *skel.CmdArgs) error {
 		return nil
 	}
 
+	allocator := utils.NewPCIAllocator(config.DefaultCNIDir)
+
+	err = allocator.Lock(netConf.DeviceID)
+	if err != nil {
+		return fmt.Errorf("cmdDel() error obtaining lock for device [%s]: %w", netConf.DeviceID, err)
+	}
+
+	logging.Debug("Acquired device lock",
+		"func", "cmdDel",
+		"DeviceID", netConf.DeviceID)
+
 	defer func() {
 		if err == nil && cRefPath != "" {
 			_ = utils.CleanCachedNetConf(cRefPath)
@@ -317,7 +328,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		"func", "cmdDel",
 		"config.DefaultCNIDir", config.DefaultCNIDir,
 		"netConf.DeviceID", netConf.DeviceID)
-	allocator := utils.NewPCIAllocator(config.DefaultCNIDir)
 	if err = allocator.DeleteAllocatedPCI(netConf.DeviceID); err != nil {
 		return fmt.Errorf("error cleaning the pci allocation for vf pci address %s: %v", netConf.DeviceID, err)
 	}

--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -270,6 +270,9 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	sm := sriov.NewSriovManager()
 
+	logging.Debug("Reset VF configuration",
+		"func", "cmdDel",
+		"netConf.DeviceID", netConf.DeviceID)
 	/* ResetVFConfig resets a VF administratively. We must run ResetVFConfig
 	   before ReleaseVF because some drivers will error out if we try to
 	   reset netdev VF with trust off. So, reset VF MAC address via PF first.
@@ -288,6 +291,10 @@ func cmdDel(args *skel.CmdArgs) error {
 			// IPAM resources
 			_, ok := err.(ns.NSPathNotExistErr)
 			if ok {
+				logging.Debug("Exiting as the network namespace does not exists anymore",
+					"func", "cmdDel",
+					"netConf.DeviceID", netConf.DeviceID,
+					"args.Netns", args.Netns)
 				return nil
 			}
 
@@ -295,6 +302,11 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		defer netns.Close()
 
+		logging.Debug("Release the VF",
+			"func", "cmdDel",
+			"netConf.DeviceID", netConf.DeviceID,
+			"args.Netns", args.Netns,
+			"args.IfName", args.IfName)
 		if err = sm.ReleaseVF(netConf, args.IfName, netns); err != nil {
 			return err
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,6 +13,11 @@ import (
 )
 
 var _ = Describe("Config", func() {
+	BeforeEach(func() {
+		DeferCleanup(func(x string) { DefaultCNIDir = x }, DefaultCNIDir)
+		DefaultCNIDir = GinkgoT().TempDir()
+	})
+
 	Context("Checking LoadConf function", func() {
 		It("Assuming correct config file - existing DeviceID", func() {
 			conf := []byte(`{
@@ -80,6 +85,7 @@ var _ = Describe("Config", func() {
 		invalidProto := "802"
 		DescribeTable("Vlan ID, QoS and Proto",
 			func(vlanID *int, vlanQoS *int, vlanProto *string, failure bool) {
+
 				s := `{
         "name": "mynet",
         "type": "sriov",


### PR DESCRIPTION
The VF might have been assigned to another running
Pod if the network namespace is not present. In cases
like this, resetting the VF might break the configuration
of the running Pod.
The above scenario might occur when the IPAM plugin takes a lot of time to complete, and the CmdDel gets called
multiple times.

Check if the namespace is still present before resetting the VF

@bn222 @SchSeba WDYT about this approach?