### PR TITLE
Revert mtu

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -27,6 +27,7 @@ type VfState struct {
 	MinTxRate    int
 	MaxTxRate    int
 	LinkState    uint32
+	MTU          int
 }
 
 // FillFromVfInfo - Fill attributes according to the provided netlink.VfInfo struct

--- a/pkg/utils/mocks/netlink_manager_mock.go
+++ b/pkg/utils/mocks/netlink_manager_mock.go
@@ -83,6 +83,24 @@ func (_m *NetlinkManager) LinkSetHardwareAddr(_a0 netlink.Link, _a1 net.Hardware
 	return r0
 }
 
+// LinkSetMTU provides a mock function with given fields: _a0, _a1
+func (_m *NetlinkManager) LinkSetMTU(_a0 netlink.Link, _a1 int) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LinkSetMTU")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(netlink.Link, int) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // LinkSetName provides a mock function with given fields: _a0, _a1
 func (_m *NetlinkManager) LinkSetName(_a0 netlink.Link, _a1 string) error {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/utils/netlink_manager.go
+++ b/pkg/utils/netlink_manager.go
@@ -22,6 +22,7 @@ type NetlinkManager interface {
 	LinkSetVfSpoofchk(netlink.Link, int, bool) error
 	LinkSetVfTrust(netlink.Link, int, bool) error
 	LinkSetVfState(netlink.Link, int, uint32) error
+	LinkSetMTU(netlink.Link, int) error
 	LinkDelAltName(netlink.Link, string) error
 }
 
@@ -90,6 +91,11 @@ func (n *MyNetlink) LinkSetVfTrust(link netlink.Link, vf int, state bool) error 
 // LinkSetVfState using NetlinkManager
 func (n *MyNetlink) LinkSetVfState(link netlink.Link, vf int, state uint32) error {
 	return netlink.LinkSetVfState(link, vf, state)
+}
+
+// LinkSetMTU using NetlinkManager
+func (n *MyNetlink) LinkSetMTU(link netlink.Link, mtu int) error {
+	return netlink.LinkSetMTU(link, mtu)
 }
 
 // LinkDelAltName using NetlinkManager


### PR DESCRIPTION
we introduce this feature in the cni to handle cases where a pod that used the vf has net_admin and change the MTU
on the VF.

when that pod is removed the VF will go back to the host and be available
for a new pod to run but when that VF gets allocated to the pod it will
remain with an unexpected MTU.