### PR TITLE
Fix error on Del cmd for user space drivers

### DIFF
--- a/pkg/cnicommands/cni.go
+++ b/pkg/cnicommands/cni.go
@@ -284,7 +284,12 @@ func CmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("cmdDel() error reseting VF: %q", err)
 	}
 
-	if !netConf.DPDKMode {
+	hasDpdkDriver, err := utils.HasDpdkDriver(netConf.DeviceID)
+	if err != nil {
+		return fmt.Errorf("cmdDel() error checking DPDK driver: %q", err)
+	}
+
+	if !hasDpdkDriver {
 		netns, err := ns.GetNS(args.Netns)
 		if err != nil {
 			// according to:


### PR DESCRIPTION
The DPDKMode var in conf is json ignored. The value is always false. This checks if the device is attached to a user space supported driver instead of relaying on this var.