### PR TITLE
Add fallback for VF VLAN configuration when protocol is unsupported

### DIFF
--- a/pkg/utils/mocks/netlink_manager_mock.go
+++ b/pkg/utils/mocks/netlink_manager_mock.go
@@ -279,6 +279,24 @@ func (_m *NetlinkManager) LinkSetVfVlanQosProto(_a0 netlink.Link, _a1 int, _a2 i
 	return r0
 }
 
+// LinkSetVfVlanQos provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *NetlinkManager) LinkSetVfVlanQos(_a0 netlink.Link, _a1 int, _a2 int, _a3 int) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LinkSetVfVlanQos")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(netlink.Link, int, int, int) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewNetlinkManager creates a new instance of NetlinkManager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewNetlinkManager(t interface {

--- a/pkg/utils/netlink_manager.go
+++ b/pkg/utils/netlink_manager.go
@@ -12,6 +12,7 @@ import (
 type NetlinkManager interface {
 	LinkByName(string) (netlink.Link, error)
 	LinkSetVfVlanQosProto(netlink.Link, int, int, int, int) error
+	LinkSetVfVlanQos(netlink.Link, int, int, int) error
 	LinkSetVfHardwareAddr(netlink.Link, int, net.HardwareAddr) error
 	LinkSetHardwareAddr(netlink.Link, net.HardwareAddr) error
 	LinkSetUp(netlink.Link) error
@@ -45,6 +46,11 @@ func (n *MyNetlink) LinkByName(name string) (netlink.Link, error) {
 // LinkSetVfVlanQosProto sets VLAN ID, QoS and Proto field for given VF using NetlinkManager
 func (n *MyNetlink) LinkSetVfVlanQosProto(link netlink.Link, vf, vlan, qos, proto int) error {
 	return netlink.LinkSetVfVlanQosProto(link, vf, vlan, qos, proto)
+}
+
+// LinkSetVfVlanQos sets VLAN ID and QoS field for given VF using NetlinkManager
+func (n *MyNetlink) LinkSetVfVlanQos(link netlink.Link, vf, vlan, qos int) error {
+	return netlink.LinkSetVfVlanQos(link, vf, vlan, qos)
 }
 
 // LinkSetVfHardwareAddr using NetlinkManager

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -212,6 +212,11 @@ func (p *pfMockNetlinkLib) LinkSetVfVlanQosProto(link netlink.Link, vfIndex, vla
 	return nil
 }
 
+func (p *pfMockNetlinkLib) LinkSetVfVlanQos(link netlink.Link, vfIndex, vlan, vlanQos int) error {
+	p.recordMethodCall("LinkSetVfVlanQos %s %d %d %d", link.Attrs().Name, vfIndex, vlan, vlanQos)
+	return nil
+}
+
 func (p *pfMockNetlinkLib) LinkSetVfHardwareAddr(pfLink netlink.Link, vfIndex int, hwaddr net.HardwareAddr) error {
 	p.recordMethodCall("LinkSetVfHardwareAddr %s %d %s", pfLink.Attrs().Name, vfIndex, hwaddr.String())
 	pfLink.Attrs().Vfs[vfIndex].Mac = hwaddr


### PR DESCRIPTION
**Why is this change needed?**

SRIOV-CNI currently configures VF VLANs using LinkSetVfVlanQosProto, which includes the VLAN protocol attribute (IFLA_VF_VLAN_PROTOCOL). However, not all kernel / driver combinations support this attribute.

On such systems, the netlink call fails with:
```
protocol not supported
```

This results in pod sandbox creation failure, even though the VF VLAN could be successfully configured without specifying the protocol

**What does this PR change?**

Attempt to configure VF VLAN using LinkSetVfVlanQosProto (current behavior)

If the operation fails with EOPNOTSUPP / “protocol not supported”:

Log a debug message

Retry VLAN configuration using the legacy LinkSetVfVlanQos API (without protocol)

Apply the same fallback logic during VF reset to ensure consistent behavior

Add netlink abstraction support and test mocks for the legacy VLAN API

**Related Issues**
Fixes: https://github.com/k8snetworkplumbingwg/sriov-cni/issues/392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry VLAN apply/restore without a VLAN protocol when a device reports the protocol as unsupported, reducing failed VLAN operations and preserving original error reporting.
  * Improved validation to avoid applying or restoring invalid or unset VLAN values.

* **Chores**
  * Added compatibility support and test/mocking hooks for VLAN QoS operations to better handle devices that don’t accept protocol parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->