### PR TITLE
close network namespace handle to avoid file descriptor leak

### DIFF
--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -72,6 +72,12 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, netns
 	if err != nil {
 		return fmt.Errorf("failed to get current NS: %v", err)
 	}
+	defer func() {
+		if err := initns.Close(); err != nil {
+			logging.Warning("failed to close init netns", "error", err)
+		}
+	}()
+
 	tempNS, err := ns.TempNetNS()
 	if err != nil {
 		return fmt.Errorf("failed to create tempNS: %v", err)
@@ -249,6 +255,11 @@ func (s *sriovManager) ReleaseVF(conf *sriovtypes.NetConf, podifName string, net
 	if err != nil {
 		return fmt.Errorf("failed to get init netns: %v", err)
 	}
+	defer func() {
+		if err := initns.Close(); err != nil {
+			logging.Warning("failed to close init netns", "error", err)
+		}
+	}()
 
 	return netns.Do(func(_ ns.NetNS) error {
 		// get VF device


### PR DESCRIPTION
Namespace handles returned by ns.GetCurrentNS() and ns.TempNetNS() open file descriptors under /proc/.../ns/net.
Ensure these handles are closed after use to avoid leaking file descriptors when the CNI plugin is invoked.

This changes prevents FD leak.

example reference- 
1. https://github.com/containernetworking/plugins/blob/main/pkg/ns/ns_linux.go#L253-L258

2)https://github.com/k8snetworkplumbingwg/sriov-cni/blob/43de7e46644fb6a84d7ad9deb23ffec6a70de660/pkg/cnicommands/cni.go#L74-L78

