### PR TITLE
fix pointer aliasing in getVfInfo loop

### DIFF
--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -319,9 +319,9 @@ func (s *sriovManager) ReleaseVF(conf *sriovtypes.NetConf, podifName string, net
 
 func getVfInfo(link netlink.Link, id int) *netlink.VfInfo {
 	attrs := link.Attrs()
-	for _, vf := range attrs.Vfs {
-		if vf.ID == id {
-			return &vf
+	for i := range attrs.Vfs {
+		if attrs.Vfs[i].ID == id {
+			return &attrs.Vfs[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
Avoid returning address of range variable, which results in pointer to reused loop variable instead of actual slice element. Use index-based iteration to return correct VfInfo reference.