### PR TITLE
fix netns error formatting

### DIFF
--- a/pkg/cnicommands/cni.go
+++ b/pkg/cnicommands/cni.go
@@ -73,7 +73,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	netns, err := ns.GetNS(args.Netns)
 	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", netns, err)
+		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 	}
 	defer netns.Close()
 
@@ -301,7 +301,7 @@ func CmdDel(args *skel.CmdArgs) error {
 				return nil
 			}
 
-			return fmt.Errorf("failed to open netns %s: %q", netns, err)
+			return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 		}
 		defer netns.Close()
 


### PR DESCRIPTION
Use args.Netns instead of netns in error messages to avoid printing invalid/uninitialized values.

This PR fixes error handling in CNI command paths (CmdAdd and CmdDel) when opening network namespaces fails.

 Changes
  - netns may be nil/uninitialized when ns.GetNS() fails
  - args.Netns correctly reflects the requested namespace path