### PR TITLE
Fix VLAN protocol configuration on s390x architecture

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/vishvananda/netlink"
@@ -13,7 +14,15 @@ const (
 	Proto8021ad = "802.1ad"
 )
 
-var VlanProtoInt = map[string]int{Proto8021q: 33024, Proto8021ad: 34984}
+// VlanProtoInt maps VLAN protocol strings to their integer values
+// TODO: Temporary workaround for netlink bug on big-endian systems.
+// Remove once netlink is updated to a version containing https://github.com/vishvananda/netlink/pull/1155
+var VlanProtoInt = func() map[string]int {
+	if runtime.GOARCH == "s390x" {
+		return map[string]int{Proto8021q: 0x81, Proto8021ad: 0xa888}
+	}
+	return map[string]int{Proto8021q: 0x8100, Proto8021ad: 0x88a8}
+}()
 
 // VfState represents the state of the VF
 type VfState struct {


### PR DESCRIPTION
SR-IOV CNI fails to configure VF VLAN on s390x (big-endian) systems with error "protocol not supported"

This patch adds architecture-specific VLAN protocol values:
- s390x (big-endian): 129 (0x0081), 43152 (0xa888)
- Other archs (little-endian): 33024 (0x8100), 34984 (0x88a8)

This PR fixes issue: https://github.com/k8snetworkplumbingwg/sriov-cni/issues/392

## Note to Reviewers

### This is a Temporary Workaround

**The proper fix has already been implemented in the upstream netlink library:**
- **Netlink PR**: https://github.com/vishvananda/netlink/pull/1155 ✅ **Merged**
- **Fix**: Properly handles endianness by skipping byte swap on big-endian architectures

### Why We Can't Use the Upstream Fix Yet

1. **Current netlink version in sriov-cni is one year old:**
   - See: https://github.com/k8snetworkplumbingwg/sriov-cni/blob/43de7e46644fb6a84d7ad9deb23ffec6a70de660/go.mod#L12
   - No new netlink releases have been published since then

2. **Recent netlink changes broke netns library compatibility(this issue for all architecture):**
   - When we attempt to bump netlink in sriov-cni, it causes failures
   - The netns library (used by sriov-cni) is incompatible with recent netlink changes
   - Details: https://github.com/k8snetworkplumbingwg/sriov-cni/pull/404


### Migration Path

**Current state:**
- ✅ Upstream fix exists in netlink (PR #1155)
- ❌ Cannot bump netlink due to netns compatibility issues
- ❌ s390x  blocked from using SR-IOV CNI

**This PR:**
- ✅ Unblock s390x
- ✅ No impact on existing architectures
- ⚠️ Temporary workaround until dependency issues resolved

**Future plan:**
1. Wait for netlink/netns compatibility issues to be resolved
2. Bump netlink dependency to version with PR #1155
3. Remove this workaround code
4. Use proper upstream fix
