### PR TITLE
chore: replace entrypoint.sh with go entrypoint 

### DIFF
--- a/.github/workflows/static-scan.yml
+++ b/.github/workflows/static-scan.yml
@@ -12,15 +12,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: run make lint
         run: make lint
-  shellcheck:
-    name: Shellcheck
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v6
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
-      with:
-        check_together: yes
   hadolint:
     runs-on: ubuntu-24.04
     name: Hadolint

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,13 @@ $(BINDIR) $(BUILDDIR) $(COVERAGE_DIR): ; $(info Creating directory $@...)
 	@mkdir -p $@
 
 .PHONY: build
-build: | $(BUILDDIR) ; $(info Building $(BINARY_NAME)...) @ ## Build SR-IOV CNI plugin
+build: build-entrypoint | $(BUILDDIR) ; $(info Building $(BINARY_NAME)...) @ ## Build SR-IOV CNI plugin
 	$Q cd $(CURDIR)/cmd/$(BINARY_NAME) && $(GO_BUILD_OPTS) go build -ldflags '$(GO_LDFLAGS)' $(GO_FLAGS) -o $(BUILDDIR)/$(BINARY_NAME) $(GO_TAGS) -v
 	$(info Done!)
+
+.PHONY: build-entrypoint
+build-entrypoint: | $(BUILDDIR) ; $(info Building entrypoint...) @ ## Build entrypoint binary
+	$Q $(GO_BUILD_OPTS) go build -o $(BUILDDIR)/entrypoint $(GO_TAGS) ./cmd/entrypoint/
 
 # Tools
 GOLANGCI_LINT = $(BINDIR)/golangci-lint

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+const (
+	defaultCNIBinDir    = "/host/opt/cni/bin"
+	defaultSRIOVBinFile = "/usr/bin/sriov"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr,
+		"This is an entrypoint script for SR-IOV CNI to overlay its\n"+
+			"binary into location in a filesystem. The binary file will\n"+
+			"be copied to the corresponding directory.\n\n"+
+			"./entrypoint\n"+
+			"\t-h --help\n"+
+			"\t--cni-bin-dir=%s\n"+
+			"\t--sriov-bin-file=%s\n"+
+			"\t--no-sleep\n",
+		defaultCNIBinDir, defaultSRIOVBinFile)
+}
+
+func run() int {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	cniBinDir := fs.String("cni-bin-dir", defaultCNIBinDir, "CNI binary destination directory")
+	sriovBinFile := fs.String("sriov-bin-file", defaultSRIOVBinFile, "Source sriov binary path")
+	noSleep := fs.Bool("no-sleep", false, "Exit after copying binary without waiting for signal")
+	fs.Usage = usage
+
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to parse flags: %v\n", err)
+		return 1
+	}
+
+	cniBinDirClean := filepath.Clean(*cniBinDir)
+	if !filepath.IsAbs(cniBinDirClean) {
+		fmt.Fprintf(os.Stderr, "cni-bin-dir must be an absolute path, got: %s\n", *cniBinDir)
+		return 1
+	}
+
+	info, err := os.Stat(cniBinDirClean)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cni-bin-dir %q does not exist: %v\n", cniBinDirClean, err)
+		return 1
+	}
+	if !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "cni-bin-dir %q is not a directory\n", cniBinDirClean)
+		return 1
+	}
+
+	if _, err := os.Stat(*sriovBinFile); err != nil {
+		fmt.Fprintf(os.Stderr, "sriov-bin-file %q does not exist: %v\n", *sriovBinFile, err)
+		return 1
+	}
+
+	binBase := filepath.Base(*sriovBinFile)
+	destPath := filepath.Join(cniBinDirClean, binBase)
+	tempPattern := fmt.Sprintf("%s.temp", binBase)
+	if err := copyFileAtomic(*sriovBinFile, cniBinDirClean, tempPattern, binBase); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to copy %q to %q: %v\n", *sriovBinFile, destPath, err)
+		return 1
+	}
+
+	if *noSleep {
+		fmt.Println("SR-IOV CNI binary installed.")
+		return 0
+	}
+
+	fmt.Println("SR-IOV CNI binary installed, waiting for termination signal.")
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(ch)
+	<-ch
+	return 0
+}
+
+// copyFileAtomic does file copy atomically
+func copyFileAtomic(srcFilePath, destDir, tempFileName, destFileName string) error {
+	tempFilePath := filepath.Join(destDir, tempFileName)
+	// check temp filepath and remove old file if exists
+	if _, err := os.Stat(tempFilePath); err == nil {
+		err = os.Remove(tempFilePath)
+		if err != nil {
+			return fmt.Errorf("cannot remove old temp file %q: %v", tempFilePath, err)
+		}
+	}
+
+	// create temp file
+	f, err := os.CreateTemp(destDir, tempFileName)
+	if err != nil {
+		return fmt.Errorf("cannot create temp file %q in %q: %v", tempFileName, destDir, err)
+	}
+	defer f.Close()
+
+	srcFile, err := os.Open(srcFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot open file %q: %v", srcFilePath, err)
+	}
+	defer srcFile.Close()
+
+	// Copy file to tempfile
+	_, err = io.Copy(f, srcFile)
+	if err != nil {
+		f.Close()
+		os.Remove(tempFilePath)
+		return fmt.Errorf("cannot write data to temp file %q: %v", tempFilePath, err)
+	}
+	if err = f.Sync(); err != nil {
+		return fmt.Errorf("cannot flush temp file %q: %v", tempFilePath, err)
+	}
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("cannot close temp file %q: %v", tempFilePath, err)
+	}
+
+	// change file mode if different
+	destFilePath := filepath.Join(destDir, destFileName)
+	_, err = os.Stat(destFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	srcFileStat, err := os.Stat(srcFilePath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Chmod(f.Name(), srcFileStat.Mode()); err != nil {
+		return fmt.Errorf("cannot set stat on temp file %q: %v", f.Name(), err)
+	}
+
+	// replace file with tempfile
+	if err := os.Rename(f.Name(), destFilePath); err != nil {
+		return fmt.Errorf("cannot replace %q with temp file %q: %v", destFilePath, tempFilePath, err)
+	}
+
+	return nil
+}
+
+func main() {
+	os.Exit(run())
+}

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+const (
+	defaultCNIBinDir    = "/host/opt/cni/bin"
+	defaultSRIOVBinFile = "/usr/bin/sriov"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr,
+		"This is an entrypoint script for SR-IOV CNI to overlay its\n"+
+			"binary into location in a filesystem. The binary file will\n"+
+			"be copied to the corresponding directory.\n\n"+
+			"./entrypoint\n"+
+			"\t-h --help\n"+
+			"\t--cni-bin-dir=%s\n"+
+			"\t--sriov-bin-file=%s\n"+
+			"\t--no-sleep\n",
+		defaultCNIBinDir, defaultSRIOVBinFile)
+}
+
+func run() int {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	cniBinDir := fs.String("cni-bin-dir", defaultCNIBinDir, "CNI binary destination directory")
+	sriovBinFile := fs.String("sriov-bin-file", defaultSRIOVBinFile, "Source sriov binary path")
+	noSleep := fs.Bool("no-sleep", false, "Exit after copying binary without waiting for signal")
+	fs.Usage = usage
+
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to parse flags: %v\n", err)
+		return 1
+	}
+
+	cniBinDirClean := filepath.Clean(*cniBinDir)
+	if !filepath.IsAbs(cniBinDirClean) {
+		fmt.Fprintf(os.Stderr, "cni-bin-dir must be an absolute path, got: %s\n", *cniBinDir)
+		return 1
+	}
+
+	info, err := os.Stat(cniBinDirClean)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cni-bin-dir %q does not exist: %v\n", cniBinDirClean, err)
+		return 1
+	}
+	if !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "cni-bin-dir %q is not a directory\n", cniBinDirClean)
+		return 1
+	}
+
+	if _, err := os.Stat(*sriovBinFile); err != nil {
+		fmt.Fprintf(os.Stderr, "sriov-bin-file %q does not exist: %v\n", *sriovBinFile, err)
+		return 1
+	}
+
+	binBase := filepath.Base(*sriovBinFile)
+	destPath := filepath.Join(cniBinDirClean, binBase)
+	tempPattern := fmt.Sprintf("%s.temp", binBase)
+	if err := copyFileAtomic(*sriovBinFile, cniBinDirClean, tempPattern, binBase); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to copy %q to %q: %v\n", *sriovBinFile, destPath, err)
+		return 1
+	}
+
+	if *noSleep {
+		fmt.Println("SR-IOV CNI binary installed.")
+		return 0
+	}
+
+	fmt.Println("SR-IOV CNI binary installed, waiting for termination signal.")
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(ch)
+	<-ch
+	return 0
+}
+
+// copyFileAtomic does file copy atomically
+func copyFileAtomic(srcFilePath, destDir, tempFileName, destFileName string) error {
+	// create temp file
+	f, err := os.CreateTemp(destDir, tempFileName)
+	if err != nil {
+		return fmt.Errorf("cannot create temp file %q in %q: %v", tempFileName, destDir, err)
+	}
+	tempFile := f.Name()
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(tempFile)
+	}()
+
+	srcFile, err := os.Open(srcFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot open file %q: %v", srcFilePath, err)
+	}
+	defer srcFile.Close()
+
+	srcFileStat, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("cannot stat source file %q: %v", srcFilePath, err)
+	}
+
+	// Copy file to tempfile
+	_, err = io.Copy(f, srcFile)
+	if err != nil {
+		return fmt.Errorf("cannot write data to temp file %q: %v", tempFile, err)
+	}
+
+	if err := os.Chmod(f.Name(), srcFileStat.Mode()); err != nil {
+		return fmt.Errorf("cannot set permissions on temp file %q: %v", f.Name(), err)
+	}
+
+	if err = f.Sync(); err != nil {
+		return fmt.Errorf("cannot flush temp file %q: %v", tempFile, err)
+	}
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("cannot close temp file %q: %v", tempFile, err)
+	}
+
+	// replace file with tempfile
+	destFilePath := filepath.Join(destDir, destFileName)
+	if err := os.Rename(f.Name(), destFilePath); err != nil {
+		return fmt.Errorf("cannot replace %q with temp file %q: %v", destFilePath, tempFile, err)
+	}
+
+	return nil
+}
+
+func main() {
+	os.Exit(run())
+}

--- a/cmd/entrypoint/main_suit_test.go
+++ b/cmd/entrypoint/main_suit_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEntrypoint(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Entrypoint Suite")
+}

--- a/cmd/entrypoint/main_test.go
+++ b/cmd/entrypoint/main_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// writeTempFile creates a temporary file with the given content and permissions.
+func writeTempFile(dir, name string, content []byte, perm os.FileMode) string {
+	path := filepath.Join(dir, name)
+	Expect(os.WriteFile(path, content, perm)).To(Succeed())
+	return path
+}
+
+var _ = Describe("copyFile", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "entrypoint-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmpDir)
+	})
+
+	It("copies file content to destination", func() {
+		content := []byte("binary-content")
+		src := writeTempFile(tmpDir, "src", content, 0o644)
+		dst := filepath.Join(tmpDir, "dst")
+
+		Expect(copyFileAtomic(src, tmpDir, "src.temp", "dst")).To(Succeed())
+
+		got, err := os.ReadFile(dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal(content))
+	})
+
+	It("preserves source file permissions on the destination", func() {
+		src := writeTempFile(tmpDir, "src", []byte("data"), 0o755)
+		dst := filepath.Join(tmpDir, "dst")
+
+		Expect(copyFileAtomic(src, tmpDir, "src.temp", "dst")).To(Succeed())
+
+		info, err := os.Stat(dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
+	})
+
+	It("overwrites an existing destination file", func() {
+		src := writeTempFile(tmpDir, "src", []byte("new-content"), 0o755)
+		dst := writeTempFile(tmpDir, "dst", []byte("old-content"), 0o644)
+
+		Expect(copyFileAtomic(src, tmpDir, "src.temp", "dst")).To(Succeed())
+
+		got, err := os.ReadFile(dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal([]byte("new-content")))
+	})
+
+	It("returns an error when the source does not exist", func() {
+		err := copyFileAtomic(filepath.Join(tmpDir, "nonexistent"), tmpDir, "src.temp", "dst")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error when the destination directory does not exist", func() {
+		src := writeTempFile(tmpDir, "src", []byte("data"), 0o755)
+		err := copyFileAtomic(src, filepath.Join(tmpDir, "no-such-dir"), "src.temp", "dst")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("run", func() {
+	var (
+		origArgs []string
+		tmpDir   string
+	)
+
+	BeforeEach(func() {
+		origArgs = os.Args
+		var err error
+		tmpDir, err = os.MkdirTemp("", "entrypoint-run-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			os.Args = origArgs
+			os.RemoveAll(tmpDir)
+		})
+	})
+
+	It("returns 1 when --cni-bin-dir is a relative path", func() {
+		src := writeTempFile(tmpDir, "sriov", []byte("bin"), 0o755)
+		os.Args = []string{"entrypoint", "--cni-bin-dir=relative/path", "--sriov-bin-file=" + src}
+		Expect(run()).To(Equal(1))
+	})
+
+	It("returns 1 when --cni-bin-dir does not exist", func() {
+		src := writeTempFile(tmpDir, "sriov", []byte("bin"), 0o755)
+		os.Args = []string{"entrypoint",
+			"--cni-bin-dir=" + filepath.Join(tmpDir, "no-such-dir"),
+			"--sriov-bin-file=" + src,
+		}
+		Expect(run()).To(Equal(1))
+	})
+
+	It("returns 1 when --cni-bin-dir points to a file, not a directory", func() {
+		notADir := writeTempFile(tmpDir, "notadir", []byte("x"), 0o644)
+		src := writeTempFile(tmpDir, "sriov", []byte("bin"), 0o755)
+		os.Args = []string{"entrypoint",
+			"--cni-bin-dir=" + notADir,
+			"--sriov-bin-file=" + src,
+		}
+		Expect(run()).To(Equal(1))
+	})
+
+	It("returns 1 when --sriov-bin-file does not exist", func() {
+		os.Args = []string{"entrypoint",
+			"--cni-bin-dir=" + tmpDir,
+			"--sriov-bin-file=" + filepath.Join(tmpDir, "no-such-binary"),
+		}
+		Expect(run()).To(Equal(1))
+	})
+
+	It("copies the binary to --cni-bin-dir and exits 0 on SIGTERM", func() {
+		binContent := []byte("#!/bin/sh\necho hello")
+		src := writeTempFile(tmpDir, "sriov", binContent, 0o755)
+		destDir, err := os.MkdirTemp("", "entrypoint-dest-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(os.RemoveAll, destDir)
+
+		entrypointBin := filepath.Join(tmpDir, "entrypoint")
+		buildOut, err := exec.Command("go", "build", "-o", entrypointBin, ".").CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "go build failed: %s", buildOut)
+
+		proc := exec.Command(entrypointBin,
+			"--cni-bin-dir="+destDir,
+			"--sriov-bin-file="+src,
+		)
+		proc.Stdout = GinkgoWriter
+		proc.Stderr = GinkgoWriter
+		Expect(proc.Start()).To(Succeed())
+		DeferCleanup(func() { _ = proc.Process.Kill() })
+
+		destFile := filepath.Join(destDir, "sriov")
+		Eventually(destFile, 5*time.Second, 50*time.Millisecond).Should(BeAnExistingFile())
+
+		got, err := os.ReadFile(destFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal(binContent))
+		info, err := os.Stat(destFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
+
+		Expect(proc.Process.Signal(syscall.SIGTERM)).To(Succeed())
+		Expect(proc.Wait()).To(Succeed())
+		Expect(proc.ProcessState.ExitCode()).To(Equal(0))
+	})
+})


### PR DESCRIPTION
Replacing `entrypoint.sh` with GO `entrypoint` since we encountered CVEs reported on busybox, which is needed by entrypoint.sh.
GO entrypoint is using copyFileAtomic as used in [multus-cn](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/pkg/cmdutils/utils.go#L26)i 