### PR TITLE
Set cni-log base directory for log file containment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.3
 require (
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
-	github.com/k8snetworkplumbingwg/cni-log v0.0.0-20230801160229-b6e062c9e0f2
+	github.com/k8snetworkplumbingwg/cni-log v0.0.0-20260713133559-c473b802cf27
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oX
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
-github.com/k8snetworkplumbingwg/cni-log v0.0.0-20230801160229-b6e062c9e0f2 h1:KB8UPZQwLge4Abuk9tNmvzffdCJgqXSN341BX98QTHg=
-github.com/k8snetworkplumbingwg/cni-log v0.0.0-20230801160229-b6e062c9e0f2/go.mod h1:/x45AlZDoJVSSV4ECDb5TcHLzrVRDllsCMDzMrtHKwk=
+github.com/k8snetworkplumbingwg/cni-log v0.0.0-20260713133559-c473b802cf27 h1:RWfBMWUddsbH1y1bBp17vy2U3ImKSiVOogfNFbbTD7k=
+github.com/k8snetworkplumbingwg/cni-log v0.0.0-20260713133559-c473b802cf27/go.mod h1:njANWoZSpyAQPn3OjzooIuQVxJKQiOMr0/8HACHfMag=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -3,6 +3,9 @@
 package logging
 
 import (
+	"fmt"
+	"os"
+
 	cnilog "github.com/k8snetworkplumbingwg/cni-log"
 )
 
@@ -15,6 +18,7 @@ const (
 )
 
 var (
+	logFileBaseDir  = "/var/log/cni-log/sriov-cni"
 	logLevelDefault = cnilog.InfoLevel
 	containerID     = ""
 	netNS           = ""
@@ -48,6 +52,12 @@ func setLogFile(fileName string) {
 		cnilog.SetLogFile("")
 		return
 	}
+	if err := os.MkdirAll(logFileBaseDir, 0o700); err != nil {
+		cnilog.SetLogStderr(true)
+		_ = cnilog.ErrorStructured(fmt.Sprintf("failed to create log directory %s, falling back to stderr: %v", logFileBaseDir, err))
+		return
+	}
+	cnilog.SetLogFileBaseDir(logFileBaseDir)
 	cnilog.SetLogFile(fileName)
 	cnilog.SetLogStderr(false)
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -177,27 +178,28 @@ var _ = g.Describe("Logging", func() {
 	})
 
 	g.Context("log files", func() {
-		var logFile *os.File
+		var logDir string
+		var logFileName string
+		var logFilePath string
 
 		g.BeforeEach(func() {
-			var err error
-			logFile, err = os.CreateTemp("", "")
-			o.Expect(err).NotTo(o.HaveOccurred())
-		})
-
-		g.AfterEach(func() {
-			o.Expect(logFile.Close()).To(o.Succeed())
-			o.Expect(os.RemoveAll(logFile.Name())).To(o.Succeed())
+			logDir = g.GinkgoT().TempDir()
+			logFileName = "test.log"
+			logFilePath = filepath.Join(logDir, logFileName)
+			logFileBaseDir = logDir
 		})
 
 		g.When("the log file is set", func() {
 			g.BeforeEach(func() {
-				Init("", logFile.Name(), "", "", "")
+				Init("", logFileName, "", "", "")
 			})
 
 			g.It("error messages are logged to log file but not to stderr", func() {
 				Error("test message", "a", "b")
 				_, _ = stderrFile.Seek(0, 0)
+				logFile, err := os.Open(logFilePath)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				defer logFile.Close()
 				out, err := io.ReadAll(logFile)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(out).Should(o.ContainSubstring("test message"))
@@ -214,13 +216,15 @@ var _ = g.Describe("Logging", func() {
 				// TODO: This triggers a data race in github.com/k8snetworkplumbingwg/cni-log; fix the datarace in the
 				// logging component and then remove the skip.
 				g.Skip("https://github.com/k8snetworkplumbingwg/cni-log/issues/15")
-				Init("", logFile.Name(), "", "", "")
+				Init("", logFileName, "", "", "")
 				setLogFile("")
 			})
 
 			g.It("logs to stderr but not to file", func() {
 				Error("test message", "a", "b")
-				_, _ = stderrFile.Seek(0, 0)
+				logFile, err := os.Open(logFilePath)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				defer logFile.Close()
 				out, err := io.ReadAll(logFile)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(out).ShouldNot(o.ContainSubstring("test message"))


### PR DESCRIPTION
Configure sriov-cni to use /var/log/cni-log/sriov-cni as the base directory for cni-log file paths. This ensures logFile values are resolved relative to a fixed directory rather than being used as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Logging now defaults to storing log files under `/var/log/cni-log/sriov-cni`, creating the directory automatically when needed.

- **Bug Fixes**
  - Improved verification that messages appear in the log file only when file logging is enabled (and are absent after disabling).

- **Tests**
  - Refreshed log file tests to use deterministic filenames within per-test temporary directories for more reliable “set” and “unset” behavior.

- **Chores**
  - Updated the `cni-log` dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->