### PR TITLE
Validate PCI address format and CNI cache path inputs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,10 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 
 	// DeviceID takes precedence; if we are given a VF pciaddr then work from there
 	if n.DeviceID != "" {
+		if err := utils.ValidatePCIAddress(n.DeviceID); err != nil {
+			return nil, fmt.Errorf("LoadConf(): %v", err)
+		}
+
 		// Get rest of the VF information
 		pfName, vfID, err := getVfInfo(n.DeviceID)
 		if err != nil {
@@ -167,6 +171,13 @@ func getVfInfo(vfPci string) (string, int, error) {
 
 // LoadConfFromCache retrieves cached NetConf returns it along with a handle for removal
 func LoadConfFromCache(args *skel.CmdArgs) (*sriovtypes.NetConf, string, error) {
+	if err := utils.ValidateCachePathComponent(args.ContainerID); err != nil {
+		return nil, "", err
+	}
+	if err := utils.ValidateCachePathComponent(args.IfName); err != nil {
+		return nil, "", err
+	}
+
 	netConf := &sriovtypes.NetConf{}
 
 	s := []string{args.ContainerID, args.IfName}

--- a/pkg/utils/pci_allocator.go
+++ b/pkg/utils/pci_allocator.go
@@ -32,6 +32,10 @@ func NewPCIAllocator(dataDir string) *PCIAllocator {
 
 // Lock gets an exclusive lock on the given PCI address, ensuring there is no other process configuring / or de-configuring the same device.
 func (p *PCIAllocator) Lock(pciAddress string) error {
+	if err := ValidatePCIAddress(pciAddress); err != nil {
+		return err
+	}
+
 	lockDir := filepath.Join(p.dataDir, "vf_lock")
 	if err := os.MkdirAll(lockDir, 0o600); err != nil {
 		return fmt.Errorf("failed to create the sriov lock directory(%q): %v", lockDir, err)
@@ -68,6 +72,10 @@ func (p *PCIAllocator) Lock(pciAddress string) error {
 // SaveAllocatedPCI creates a file with the pci address as a name and the network namespace as the content
 // return error if the file was not created
 func (p *PCIAllocator) SaveAllocatedPCI(pciAddress, netNS string) error {
+	if err := ValidatePCIAddress(pciAddress); err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(p.dataDir, 0o600); err != nil {
 		return fmt.Errorf("failed to create the sriov data directory(%q): %v", p.dataDir, err)
 	}
@@ -84,6 +92,10 @@ func (p *PCIAllocator) SaveAllocatedPCI(pciAddress, netNS string) error {
 // DeleteAllocatedPCI Remove the allocated PCI file
 // return error if the file doesn't exist
 func (p *PCIAllocator) DeleteAllocatedPCI(pciAddress string) error {
+	if err := ValidatePCIAddress(pciAddress); err != nil {
+		return err
+	}
+
 	pciPath := filepath.Join(p.dataDir, pciAddress)
 	if err := os.Remove(pciPath); err != nil {
 		return fmt.Errorf("error removing PCI address lock file %s: %v", pciPath, err)
@@ -95,6 +107,10 @@ func (p *PCIAllocator) DeleteAllocatedPCI(pciAddress string) error {
 // if it exists we also check the network namespace still exist if not we delete the allocation
 // The function will return an error if the pci is still allocated to a running pod
 func (p *PCIAllocator) IsAllocated(pciAddress string) (bool, error) {
+	if err := ValidatePCIAddress(pciAddress); err != nil {
+		return false, err
+	}
+
 	pciPath := filepath.Join(p.dataDir, pciAddress)
 	_, err := os.Stat(pciPath)
 	if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,12 +7,35 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	sriovtypes "github.com/k8snetworkplumbingwg/sriov-cni/pkg/types"
 )
+
+var pciBDFRegex = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`)
+
+// ValidatePCIAddress checks that pciAddress is in standard BDF format (DDDD:BB:DD.F).
+func ValidatePCIAddress(pciAddress string) error {
+	if !pciBDFRegex.MatchString(pciAddress) {
+		return fmt.Errorf("invalid PCI address format: %s", pciAddress)
+	}
+	return nil
+}
+
+// ValidateCachePathComponent rejects values that could cause path traversal when
+// used as a filename component in the CNI cache directory.
+func ValidateCachePathComponent(value string) error {
+	if value == "" {
+		return fmt.Errorf("cache path component must not be empty")
+	}
+	if strings.Contains(value, "/") || strings.Contains(value, "..") {
+		return fmt.Errorf("cache path component contains invalid characters: %s", value)
+	}
+	return nil
+}
 
 var (
 	sriovConfigured = "/sriov_numvfs"
@@ -253,6 +276,13 @@ func HasDpdkDriver(pciAddr string) (bool, error) {
 // SaveNetConf takes in container ID, data dir and Pod interface name as string and a json encoded struct Conf
 // and save this Conf in data dir
 func SaveNetConf(cid, dataDir, podIfName string, netConf *sriovtypes.NetConf) error {
+	if err := ValidateCachePathComponent(cid); err != nil {
+		return err
+	}
+	if err := ValidateCachePathComponent(podIfName); err != nil {
+		return err
+	}
+
 	netConfBytes, err := json.Marshal(netConf)
 	if err != nil {
 		return fmt.Errorf("error serializing delegate netConf: %v", err)


### PR DESCRIPTION
Add BDF format validation for deviceID before it is used in sysfs path construction and PCI allocator file operations. Add path component validation for ContainerID and IfName before they are used in cache file path construction.

Validation is applied at two layers: at the entry points in LoadConf/LoadConfFromCache/SaveNetConf, and as a secondary guard in each PCIAllocator method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for PCI addresses before device-related operations proceed.
  * Improved cache handling by rejecting invalid container and interface names earlier.
  * Prevented unsafe cache/file path construction from empty or path-traversal-like values.
  * Added upfront checks when saving and reading network configuration to reduce invalid input errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->