### PR TITLE
Clear VF promiscuous mode on CNI ADD and DEL

### DIFF
--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -97,6 +97,16 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, netns
 		return fmt.Errorf("error: %v. Failed to get VF netdevice with name %s", err, linkName)
 	}
 
+	// Clear leftover promiscuity before handing the VF to the pod. CNI DEL is
+	// best-effort, so a previous allocation may have left the host VF promiscuous.
+	logging.Debug("Clear VF device promiscuous mode",
+		"func", "SetupVF",
+		"linkObj", linkObj,
+		"currentPromisc", linkObj.Attrs().Promisc)
+	if err = s.clearPromisc(linkObj); err != nil {
+		return fmt.Errorf("failed to clear promiscuous mode for link %s: %v", linkName, err)
+	}
+
 	// Save the original effective MAC address before overriding it
 	conf.OrigVfState.EffectiveMAC = linkObj.Attrs().HardwareAddr.String()
 
@@ -315,6 +325,18 @@ func (s *sriovManager) ReleaseVF(conf *sriovtypes.NetConf, podifName string, net
 			}
 		}
 
+		// Always clear promiscuity before returning the VF to the host. Restoring
+		// a previously saved count can preserve a leaked promisc state if an
+		// earlier CNI DEL never ran. The flag persists across netns moves.
+		logging.Debug("Clear VF device promiscuous mode",
+			"func", "ReleaseVF",
+			"linkObj", linkObj,
+			"conf.OrigVfState.HostIFName", conf.OrigVfState.HostIFName,
+			"currentPromisc", linkObj.Attrs().Promisc)
+		if err = s.clearPromisc(linkObj); err != nil {
+			return fmt.Errorf("failed to clear promiscuous mode for link %s: %v", conf.OrigVfState.HostIFName, err)
+		}
+
 		// move VF device to init netns
 		logging.Debug("Move VF device to init netns",
 			"func", "ReleaseVF",
@@ -444,7 +466,7 @@ func (s *sriovManager) FillOriginalVfInfo(conf *sriovtypes.NetConf) error {
 	}
 	conf.OrigVfState.FillFromVfInfo(vfState)
 
-	// add also MTU to the vf info in the vf is we have an interface name
+	// Capture netdev attributes (MTU, promiscuity) when the VF has an interface name
 	if conf.OrigVfState.HostIFName != "" {
 		vfLink, err := s.nLink.LinkByName(conf.OrigVfState.HostIFName)
 		if err != nil {
@@ -454,6 +476,17 @@ func (s *sriovManager) FillOriginalVfInfo(conf *sriovtypes.NetConf) error {
 	}
 
 	return err
+}
+
+// clearPromisc drives the netdev promiscuity reference count to zero.
+// Promiscuity is a reference count; SetPromiscOff decrements by one.
+func (s *sriovManager) clearPromisc(linkObj netlink.Link) error {
+	for current := linkObj.Attrs().Promisc; current > 0; current-- {
+		if err := s.nLink.SetPromiscOff(linkObj); err != nil {
+			return fmt.Errorf("failed to disable promiscuous mode for link %s: %q", linkObj.Attrs().Name, err)
+		}
+	}
+	return nil
 }
 
 // ResetVFConfig reset a VF to its original state

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -27,6 +27,49 @@ var _ = Describe("Sriov", func() {
 		t = GinkgoT()
 	})
 
+	Context("Checking clearPromisc function", func() {
+		It("Calls SetPromiscOff until promiscuity reaches 0", func() {
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:   1000,
+				Name:    "enp175s6",
+				Promisc: 3,
+			}}
+			mocked := &mocks_utils.NetlinkManager{}
+			mocked.On("SetPromiscOff", fakeLink).Return(nil)
+			sm := sriovManager{nLink: mocked}
+			err := sm.clearPromisc(fakeLink)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertNumberOfCalls(t, "SetPromiscOff", 3)
+		})
+
+		It("Does nothing when promiscuity is already 0", func() {
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:   1000,
+				Name:    "enp175s6",
+				Promisc: 0,
+			}}
+			mocked := &mocks_utils.NetlinkManager{}
+			sm := sriovManager{nLink: mocked}
+			err := sm.clearPromisc(fakeLink)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertNotCalled(t, "SetPromiscOff", mock.Anything)
+		})
+
+		It("Returns error when SetPromiscOff fails", func() {
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:   1000,
+				Name:    "enp175s6",
+				Promisc: 1,
+			}}
+			mocked := &mocks_utils.NetlinkManager{}
+			mocked.On("SetPromiscOff", fakeLink).Return(fmt.Errorf("device busy"))
+			sm := sriovManager{nLink: mocked}
+			err := sm.clearPromisc(fakeLink)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to disable promiscuous mode"))
+		})
+	})
+
 	Context("Checking SetupVF function", func() {
 		var (
 			podifName string
@@ -77,6 +120,39 @@ var _ = Describe("Sriov", func() {
 			err = sm.SetupVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(netconf.OrigVfState.EffectiveMAC).To(Equal("6e:16:06:0e:b7:e9"))
+		})
+
+		It("Clears leftover promiscuous mode before moving VF to pod", func() {
+			targetNetNS, err := testutils.NewNS()
+			defer func() {
+				if targetNetNS != nil {
+					targetNetNS.Close()
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+			mocked := &mocks_utils.NetlinkManager{}
+			mockedPciUtils := &mocks.PciUtils{}
+			fakeMac, err := net.ParseMAC("6e:16:06:0e:b7:e9")
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:        1000,
+				Name:         "dummylink",
+				HardwareAddr: fakeMac,
+				Promisc:      2,
+			}}
+
+			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			mocked.On("SetPromiscOff", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, mock.Anything).Return(nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
+			mocked.On("LinkSetUp", fakeLink).Return(nil)
+			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
+			mockedPciUtils.On("EnableOptimisticDad", mock.AnythingOfType("string")).Return(nil)
+			sm := sriovManager{nLink: mocked, utils: mockedPciUtils}
+			err = sm.SetupVF(netconf, podifName, targetNetNS)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertNumberOfCalls(t, "SetPromiscOff", 2)
 		})
 
 		It("Setting VF's MAC address", func() {
@@ -544,6 +620,113 @@ var _ = Describe("Sriov", func() {
 			err = sm.ReleaseVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
 			mocked.AssertExpectations(t)
+		})
+
+		It("Clears promiscuous mode when raised inside the pod", func() {
+			netconf.OrigVfState.EffectiveMAC = ""
+			targetNetNS, err := testutils.NewNS()
+			defer func() {
+				if targetNetNS != nil {
+					targetNetNS.Close()
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:   1000,
+				Name:    "dummylink",
+				Promisc: 1,
+			}}
+			mocked := &mocks_utils.NetlinkManager{}
+
+			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
+			mocked.On("SetPromiscOff", fakeLink).Return(nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
+			sm := sriovManager{nLink: mocked}
+			err = sm.ReleaseVF(netconf, podifName, targetNetNS)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertExpectations(t)
+		})
+
+		It("Does not call SetPromiscOff when promiscuity is already 0", func() {
+			netconf.OrigVfState.EffectiveMAC = ""
+			targetNetNS, err := testutils.NewNS()
+			defer func() {
+				if targetNetNS != nil {
+					targetNetNS.Close()
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:   1000,
+				Name:    "dummylink",
+				Promisc: 0,
+			}}
+			mocked := &mocks_utils.NetlinkManager{}
+
+			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
+			sm := sriovManager{nLink: mocked}
+			err = sm.ReleaseVF(netconf, podifName, targetNetNS)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertNotCalled(t, "SetPromiscOff", mock.Anything)
+			mocked.AssertNotCalled(t, "SetPromiscOn", mock.Anything)
+		})
+
+		It("Calls SetPromiscOff multiple times when promiscuity count is greater than 1", func() {
+			netconf.OrigVfState.EffectiveMAC = ""
+			targetNetNS, err := testutils.NewNS()
+			defer func() {
+				if targetNetNS != nil {
+					targetNetNS.Close()
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:   1000,
+				Name:    "dummylink",
+				Promisc: 2,
+			}}
+			mocked := &mocks_utils.NetlinkManager{}
+
+			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
+			mocked.On("SetPromiscOff", fakeLink).Return(nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
+			sm := sriovManager{nLink: mocked}
+			err = sm.ReleaseVF(netconf, podifName, targetNetNS)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertNumberOfCalls(t, "SetPromiscOff", 2)
+		})
+
+		It("Returns error when SetPromiscOff fails", func() {
+			netconf.OrigVfState.EffectiveMAC = ""
+			targetNetNS, err := testutils.NewNS()
+			defer func() {
+				if targetNetNS != nil {
+					targetNetNS.Close()
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:   1000,
+				Name:    "dummylink",
+				Promisc: 1,
+			}}
+			mocked := &mocks_utils.NetlinkManager{}
+
+			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
+			mocked.On("SetPromiscOff", fakeLink).Return(fmt.Errorf("device busy"))
+			sm := sriovManager{nLink: mocked}
+			err = sm.ReleaseVF(netconf, podifName, targetNetNS)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to clear promiscuous mode"))
 		})
 	})
 	Context("Checking FillOriginalVfInfo function", func() {

--- a/pkg/utils/mocks/netlink_manager_mock.go
+++ b/pkg/utils/mocks/netlink_manager_mock.go
@@ -279,6 +279,42 @@ func (_m *NetlinkManager) LinkSetVfVlanQosProto(_a0 netlink.Link, _a1 int, _a2 i
 	return r0
 }
 
+// SetPromiscOff provides a mock function with given fields: _a0
+func (_m *NetlinkManager) SetPromiscOff(_a0 netlink.Link) error {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetPromiscOff")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(netlink.Link) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetPromiscOn provides a mock function with given fields: _a0
+func (_m *NetlinkManager) SetPromiscOn(_a0 netlink.Link) error {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetPromiscOn")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(netlink.Link) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewNetlinkManager creates a new instance of NetlinkManager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewNetlinkManager(t interface {

--- a/pkg/utils/netlink_manager.go
+++ b/pkg/utils/netlink_manager.go
@@ -24,6 +24,8 @@ type NetlinkManager interface {
 	LinkSetVfState(netlink.Link, int, uint32) error
 	LinkSetMTU(netlink.Link, int) error
 	LinkDelAltName(netlink.Link, string) error
+	SetPromiscOn(netlink.Link) error
+	SetPromiscOff(netlink.Link) error
 }
 
 // MyNetlink NetlinkManager
@@ -105,4 +107,14 @@ func (n *MyNetlink) LinkSetMTU(link netlink.Link, mtu int) error {
 // LinkDelAltName using NetlinkManager
 func (n *MyNetlink) LinkDelAltName(link netlink.Link, altName string) error {
 	return netlink.LinkDelAltName(link, altName)
+}
+
+// SetPromiscOn using NetlinkManager
+func (n *MyNetlink) SetPromiscOn(link netlink.Link) error {
+	return netlink.SetPromiscOn(link)
+}
+
+// SetPromiscOff using NetlinkManager
+func (n *MyNetlink) SetPromiscOff(link netlink.Link) error {
+	return netlink.SetPromiscOff(link)
 }

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -295,6 +295,16 @@ func (p *pfMockNetlinkLib) LinkDelAltName(link netlink.Link, name string) error 
 	return netlink.LinkDelAltName(link, name)
 }
 
+func (p *pfMockNetlinkLib) SetPromiscOn(link netlink.Link) error {
+	p.recordMethodCallf("SetPromiscOn %s", link.Attrs().Name)
+	return netlink.SetPromiscOn(link)
+}
+
+func (p *pfMockNetlinkLib) SetPromiscOff(link netlink.Link) error {
+	p.recordMethodCallf("SetPromiscOff %s", link.Attrs().Name)
+	return netlink.SetPromiscOff(link)
+}
+
 func (p *pfMockNetlinkLib) recordMethodCallf(format string, a ...any) {
 	message := fmt.Sprintf(format+"\n", a...)
 	//nolint:gosec


### PR DESCRIPTION
Pods that enable promiscuous mode on an SR-IOV VF can leave that state behind after deletion. Recycled VFs then remain promiscuous on the host, which has been reported to cause networking side effects such as instability and increased pause-frame counters on the PF.
    
Because CNI DEL is best-effort, always drive the promiscuity reference count to zero on DEL rather than restoring a previously saved value (which can itself be a leaked leftover). Also clear promiscuity on ADD before moving the VF into the pod as a second line of defense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Automatically clears leftover promiscuous mode before assigning an SR-IOV virtual function to a pod.
  - Clears promiscuous mode when returning a virtual function to the host.
  - Reports an error if promiscuous mode cannot be disabled, preventing incomplete network-interface transitions.
- **Tests**
  - Added coverage for repeated cleanup, already-clean interfaces, and cleanup failures throughout the virtual-function lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->