### PR TITLE
Perform PCIe FLR on VF during CNI DEL

### DIFF
--- a/pkg/cnicommands/cni.go
+++ b/pkg/cnicommands/cni.go
@@ -73,7 +73,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	netns, err := ns.GetNS(args.Netns)
 	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+		return fmt.Errorf("failed to open netns %q: %w", args.Netns, err)
 	}
 	defer netns.Close()
 
@@ -261,11 +261,6 @@ func CmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
-	// https://github.com/kubernetes/kubernetes/pull/35240
-	if args.Netns == "" {
-		return nil
-	}
-
 	// Verify VF ID existence.
 	if _, err := utils.GetVfid(netConf.DeviceID, netConf.Master); err != nil {
 		return fmt.Errorf("cmdDel() error obtaining VF ID: %q", err)
@@ -285,34 +280,55 @@ func CmdDel(args *skel.CmdArgs) error {
 	}
 
 	if !netConf.DPDKMode {
-		netns, err := ns.GetNS(args.Netns)
-		if err != nil {
-			// according to:
-			// https://github.com/kubernetes/kubernetes/issues/43014#issuecomment-287164444
-			// if provided path does not exist (e.x. when node was restarted)
-			// plugin should silently return with success after releasing
-			// IPAM resources
-			_, ok := err.(ns.NSPathNotExistErr)
-			if ok {
-				logging.Debug("Exiting as the network namespace does not exists anymore",
-					"func", "cmdDel",
-					"netConf.DeviceID", netConf.DeviceID,
-					"args.Netns", args.Netns)
-				return nil
+		// Empty Netns (https://github.com/kubernetes/kubernetes/pull/35240) and a
+		// vanished netns path both mean ReleaseVF cannot run; continue with FLR
+		// and PCI allocator cleanup below.
+		// https://github.com/kubernetes/kubernetes/issues/43014#issuecomment-287164444
+		if args.Netns == "" {
+			logging.Debug("Empty network namespace path, skipping ReleaseVF",
+				"func", "cmdDel",
+				"netConf.DeviceID", netConf.DeviceID)
+		} else if netns, err := ns.GetNS(args.Netns); err != nil {
+			if _, ok := err.(ns.NSPathNotExistErr); !ok {
+				return fmt.Errorf("failed to open netns %q: %w", args.Netns, err)
 			}
+			logging.Debug("Network namespace does not exist anymore, skipping ReleaseVF",
+				"func", "cmdDel",
+				"netConf.DeviceID", netConf.DeviceID,
+				"args.Netns", args.Netns)
+		} else {
+			defer func() {
+				if cerr := netns.Close(); cerr != nil {
+					if _, ok := cerr.(ns.NSPathNotExistErr); !ok {
+						logging.Warning("failed to close netns",
+							"func", "cmdDel",
+							"args.Netns", args.Netns,
+							"error", cerr)
+					}
+				}
+			}()
 
-			return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+			logging.Debug("Release the VF",
+				"func", "cmdDel",
+				"netConf.DeviceID", netConf.DeviceID,
+				"args.Netns", args.Netns,
+				"args.IfName", args.IfName)
+			if err := sm.ReleaseVF(netConf, args.IfName, netns); err != nil {
+				return err
+			}
 		}
-		defer netns.Close()
+	}
 
-		logging.Debug("Release the VF",
+	// Issue a PCIe Function Level Reset to clear hardware state (flow rules,
+	// DMA mappings, queue configs) that kernel-level resets cannot reach.
+	logging.Debug("PCIe FLR on VF",
+		"func", "cmdDel",
+		"netConf.DeviceID", netConf.DeviceID)
+	if err := utils.PCIeFLR(netConf.DeviceID); err != nil {
+		logging.Warning("failed to perform PCIe FLR on VF, hardware state may be stale",
 			"func", "cmdDel",
-			"netConf.DeviceID", netConf.DeviceID,
-			"args.Netns", args.Netns,
-			"args.IfName", args.IfName)
-		if err := sm.ReleaseVF(netConf, args.IfName, netns); err != nil {
-			return err
-		}
+			"DeviceID", netConf.DeviceID,
+			"error", err)
 	}
 
 	// Mark the pci address as released

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,8 @@ var (
 	SysV6NdiscNotify = "/proc/sys/net/ipv6/conf/"
 	// UserspaceDrivers is a list of driver names that don't have netlink representation for their devices
 	UserspaceDrivers = []string{"vfio-pci", "uio_pci_generic", "igb_uio"}
+	// pciBDFPattern matches a canonical sysfs PCI address (domain:bus:device.function).
+	pciBDFPattern = regexp.MustCompile(`(?i)^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$`)
 )
 
 // EnableArpAndNdiscNotify enables IPv4 arp_notify and IPv6 ndisc_notify for netdev
@@ -228,6 +231,20 @@ func GetVFLinkNamesFromVFID(pfName string, vfID int) ([]string, error) {
 	}
 
 	return names, nil
+}
+
+// PCIeFLR triggers a PCIe Function Level Reset on the given PCI device.
+// This clears all VF hardware state (flow rules, DMA mappings, queues) that
+// persists across netns moves and kernel-level resets.
+func PCIeFLR(pciAddr string) error {
+	if !pciBDFPattern.MatchString(pciAddr) {
+		return fmt.Errorf("PCIE FLR: invalid PCI address %q", pciAddr)
+	}
+	resetPath := filepath.Join(SysBusPci, pciAddr, "reset")
+	if err := os.WriteFile(resetPath, []byte("1"), 0); err != nil {
+		return fmt.Errorf("PCIE FLR: %w", err)
+	}
+	return nil
 }
 
 // HasDpdkDriver checks if a device is attached to dpdk supported driver

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -191,6 +191,30 @@ var _ = Describe("Utils", func() {
 		})
 	})
 
+	Context("Checking PCIeFLR function", func() {
+		It("should write '1' to the sysfs reset file for an existing VF", func() {
+			resetPath := filepath.Join(SysBusPci, "0000:af:06.0", "reset")
+			err := os.WriteFile(resetPath, []byte(""), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = PCIeFLR("0000:af:06.0")
+			Expect(err).NotTo(HaveOccurred())
+
+			data, err := os.ReadFile(resetPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(Equal("1"))
+		})
+		It("should return an error for a non-existing VF PCI address", func() {
+			err := PCIeFLR("0000:ff:00.0")
+			Expect(err).To(HaveOccurred())
+		})
+		It("should reject non-canonical PCI addresses", func() {
+			err := PCIeFLR("../af:06.0")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid PCI address"))
+		})
+	})
+
 	Context("Checking SaveNetConf function", func() {
 		var tmpDir string
 


### PR DESCRIPTION
Issue a PCIe Function Level Reset on the VF after releasing it back to the host. FLR clears hardware-level state (flow rules, DMA mappings, queue configurations) that persists across network namespace moves and kernel-level resets.

The reset is unconditional and non-fatal: if the sysfs reset file is absent or the write fails, a warning is logged and CmdDel continues.

As a side-effect, refactor the netns-gone path so that FLR and PCI allocation cleanup still run when the pod network namespace no longer exists (e.g. after a node restart or force-delete). Previously, CmdDel returned early in this case, leaving a stale PCI allocation file behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network namespace error handling so hardware cleanup can proceed when the namespace is missing/unavailable.
  * Added PCIe Function Level Reset as part of virtual function cleanup; reset failures now log warnings while cleanup continues.
  * Netns open/close errors are handled more precisely, including better error propagation for open failures.
* **Tests**
  * Added unit tests covering PCIe Function Level Reset behavior for valid, non-existent, and invalid PCI address inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->