### PR TITLE
fix: run deferred rollback on every ADD error

### DIFF
--- a/pkg/cnicommands/cni.go
+++ b/pkg/cnicommands/cni.go
@@ -36,7 +36,7 @@ func getEnvArgs(envArgsString string) (*envArgs, error) {
 	return nil, nil
 }
 
-func CmdAdd(args *skel.CmdArgs) (err error) {
+func CmdAdd(args *skel.CmdArgs) (returnErr error) {
 	if err := config.SetLogging(args.StdinData, args.ContainerID, args.Netns, args.IfName); err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		return fmt.Errorf("failed to get original vf information: %v", err)
 	}
 	defer func() {
-		if err != nil {
+		if returnErr != nil {
 			err := netns.Do(func(_ ns.NetNS) error {
 				_, err := netlink.LinkByName(args.IfName)
 				return err
@@ -130,7 +130,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		}
 
 		defer func() {
-			if err != nil {
+			if returnErr != nil {
 				_ = ipam.ExecDel(netConf.IPAM.Type, args.StdinData)
 			}
 		}()

--- a/pkg/cnicommands/cni.go
+++ b/pkg/cnicommands/cni.go
@@ -36,7 +36,7 @@ func getEnvArgs(envArgsString string) (*envArgs, error) {
 	return nil, nil
 }
 
-func CmdAdd(args *skel.CmdArgs) error {
+func CmdAdd(args *skel.CmdArgs) (err error) {
 	if err := config.SetLogging(args.StdinData, args.ContainerID, args.Netns, args.IfName); err != nil {
 		return err
 	}

--- a/test/integration/test_sriov_cni.sh
+++ b/test/integration/test_sriov_cni.sh
@@ -82,9 +82,11 @@ test_vlan_reset_on_invalid_mac() {
 EOM
 
   export CNI_COMMAND=ADD
+  : > "${DEFAULT_CNI_DIR}/enp175s0f1.calls"
   assert_fail invoke_sriov_cni
-  assert_file_contains "${DEFAULT_CNI_DIR}/enp175s0f1.calls" "LinkSetVfVlanQosProto enp175s0f1 0 1234 0 33024"
-  assert_file_contains "${DEFAULT_CNI_DIR}/enp175s0f1.calls" "LinkSetVfVlanQosProto enp175s0f1 0 0 0 33024"
+  assert_equals "LinkSetVfVlanQosProto enp175s0f1 0 1234 0 33024
+LinkSetVfVlanQosProto enp175s0f1 0 0 0 33024" \
+    "$(grep '^LinkSetVfVlanQosProto ' "${DEFAULT_CNI_DIR}/enp175s0f1.calls")"
 }
 
 test_mtu_reset() {

--- a/test/integration/test_sriov_cni.sh
+++ b/test/integration/test_sriov_cni.sh
@@ -66,6 +66,27 @@ EOM
 }
 
 
+test_vlan_reset_on_invalid_mac() {
+  create_network_ns "container_1"
+  export CNI_IFNAME=net1
+
+  read -r -d '' CNI_INPUT <<- EOM
+  {
+    "type": "sriov",
+    "cniVersion": "0.3.1",
+    "name": "sriov-network",
+    "vlan": 1234,
+    "deviceID": "0000:af:06.0",
+    "mac": "invalid-mac"
+  }
+EOM
+
+  export CNI_COMMAND=ADD
+  assert_fail invoke_sriov_cni
+  assert_file_contains "${DEFAULT_CNI_DIR}/enp175s0f1.calls" "LinkSetVfVlanQosProto enp175s0f1 0 1234 0 33024"
+  assert_file_contains "${DEFAULT_CNI_DIR}/enp175s0f1.calls" "LinkSetVfVlanQosProto enp175s0f1 0 0 0 33024"
+}
+
 test_mtu_reset() {
 
   create_network_ns "container_1"


### PR DESCRIPTION
`CmdAdd` checks an outer `err` variable in its deferred rollback, but errors declared in an inner scope do not update it. For example, `ApplyVFConfig` sets VLAN 1234 and then fails to parse an invalid MAC address; ADD returns an error while the VLAN change is left in place.

Use a named error result so deferred cleanup observes the error actually returned by ADD, including errors from nested scopes and the final result write.

Add a regression to the existing integration suite. It invokes ADD with a VLAN and invalid MAC using the project's fake sysfs/netlink support and real Linux network namespaces. Before the fix only the VLAN 1234 call is recorded; after the fix the original VLAN 0 is restored. No DEL call is used to obtain the cleanup.

Validation:
- Regression fails on upstream and passes with this change.
- `make test-race build test-integration`: passed, including all six integration tests.
- `make lint` with the repository-pinned golangci-lint v2.7.2: 0 issues.

The integration suite uses dummy interfaces and mocked VF operations; physical SR-IOV hardware was not tested.

Fixes #233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup handling when network setup operations fail.
  * Ensured VLAN settings are reset after an invalid MAC address causes setup to fail.

* **Tests**
  * Expanded integration coverage for VLAN reset behavior during failed SR-IOV network setup.
  * Verified that VLAN updates occur in the expected order, including the final reset to VLAN 0.
  * Added checks to confirm cleanup actions run in the correct failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->