### PR TITLE
follow up for PR #436

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,6 +20,22 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("Checking LoadConf function", func() {
+		DescribeTable("Rejecting invalid DeviceID values",
+			func(deviceID string) {
+				conf := []byte(fmt.Sprintf(`{
+        "name": "mynet",
+        "type": "sriov",
+        "deviceID": %q
+}`, deviceID))
+
+				_, err := LoadConf(conf)
+				Expect(err).To(MatchError("LoadConf(): invalid PCI address format: " + deviceID))
+			},
+			Entry("path traversal", "../../0000:af:06.1"),
+			Entry("missing domain", "af:06.1"),
+			Entry("invalid function", "0000:af:06.8"),
+		)
+
 		It("Assuming correct config file - existing DeviceID", func() {
 			conf := []byte(`{
         "name": "mynet",
@@ -168,6 +185,21 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("pci address 0000:af:06.1 is already allocated"))
 		})
 
+	})
+	Context("Checking LoadConfFromCache function", func() {
+		DescribeTable("Rejecting invalid cache path components",
+			func(containerID, ifName string) {
+				args := &skel.CmdArgs{ContainerID: containerID, IfName: ifName}
+
+				_, _, err := LoadConfFromCache(args)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("cache path component"))
+			},
+			Entry("empty container ID", "", "net1"),
+			Entry("container ID path traversal", "../escape", "net1"),
+			Entry("empty interface name", "container-id", ""),
+			Entry("interface name path traversal", "container-id", "../escape"),
+		)
 	})
 	Context("Checking getVfInfo function", func() {
 		It("Assuming existing PF", func() {

--- a/pkg/utils/pci_allocator_test.go
+++ b/pkg/utils/pci_allocator_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -17,6 +19,32 @@ var _ = Describe("PCIAllocator", func() {
 			targetNetNS.Close()
 			err = testutils.UnmountNS(targetNetNS)
 		}
+	})
+
+	Context("PCI address validation", func() {
+		DescribeTable("rejects invalid PCI addresses before accessing the filesystem",
+			func(operation func(*PCIAllocator, string) error) {
+				dataDir := GinkgoT().TempDir()
+				allocator := NewPCIAllocator(dataDir)
+
+				err := operation(allocator, "../escape")
+				Expect(err).To(MatchError("invalid PCI address format: ../escape"))
+				Expect(filepath.Join(dataDir, "pci")).ToNot(BeADirectory())
+			},
+			Entry("Lock", func(allocator *PCIAllocator, pciAddress string) error {
+				return allocator.Lock(pciAddress)
+			}),
+			Entry("SaveAllocatedPCI", func(allocator *PCIAllocator, pciAddress string) error {
+				return allocator.SaveAllocatedPCI(pciAddress, "/test/netns")
+			}),
+			Entry("DeleteAllocatedPCI", func(allocator *PCIAllocator, pciAddress string) error {
+				return allocator.DeleteAllocatedPCI(pciAddress)
+			}),
+			Entry("IsAllocated", func(allocator *PCIAllocator, pciAddress string) error {
+				_, err := allocator.IsAllocated(pciAddress)
+				return err
+			}),
+		)
 	})
 
 	Context("IsAllocated", func() {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,7 +15,7 @@ import (
 	sriovtypes "github.com/k8snetworkplumbingwg/sriov-cni/pkg/types"
 )
 
-var pciBDFRegex = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`)
+var pciBDFRegex = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-1][0-9a-fA-F]\.[0-7]$`)
 
 // ValidatePCIAddress checks that pciAddress is in standard BDF format (DDDD:BB:DD.F).
 func ValidatePCIAddress(pciAddress string) error {
@@ -31,7 +31,7 @@ func ValidateCachePathComponent(value string) error {
 	if value == "" {
 		return fmt.Errorf("cache path component must not be empty")
 	}
-	if strings.Contains(value, "/") || strings.Contains(value, "..") {
+	if strings.Contains(value, "/") || value == "." || value == ".." {
 		return fmt.Errorf("cache path component contains invalid characters: %s", value)
 	}
 	return nil

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,6 +20,56 @@ import (
 )
 
 var _ = Describe("Utils", func() {
+	Context("Checking ValidatePCIAddress function", func() {
+		DescribeTable("valid PCI addresses",
+			func(pciAddress string) {
+				Expect(ValidatePCIAddress(pciAddress)).To(Succeed())
+			},
+			Entry("lowercase address", "0000:af:06.0"),
+			Entry("uppercase address", "ABCD:EF:1F.7"),
+			Entry("numeric address", "1234:56:18.1"),
+		)
+
+		DescribeTable("invalid PCI addresses",
+			func(pciAddress string) {
+				Expect(ValidatePCIAddress(pciAddress)).To(MatchError("invalid PCI address format: " + pciAddress))
+			},
+			Entry("empty address", ""),
+			Entry("missing domain", "af:06.0"),
+			Entry("short domain", "000:af:06.0"),
+			Entry("short bus", "0000:a:06.0"),
+			Entry("short device", "0000:af:6.0"),
+			Entry("missing function", "0000:af:06"),
+			Entry("device outside the supported range", "0000:af:20.0"),
+			Entry("function outside the supported range", "0000:af:06.8"),
+			Entry("non-hexadecimal character", "0000:ag:06.0"),
+			Entry("path traversal", "../../0000:af:06.0"),
+			Entry("trailing data", "0000:af:06.0/driver"),
+		)
+	})
+
+	Context("Checking ValidateCachePathComponent function", func() {
+		DescribeTable("valid cache path components",
+			func(component string) {
+				Expect(ValidateCachePathComponent(component)).To(Succeed())
+			},
+			Entry("container ID", "85b3788e91c2"),
+			Entry("CNI interface name", "net1"),
+			Entry("component with a single dot", "eth0.100"),
+			Entry("interface name with embedded double dots", "eth..0"),
+		)
+
+		DescribeTable("invalid cache path components",
+			func(component, expectedError string) {
+				Expect(ValidateCachePathComponent(component)).To(MatchError(expectedError))
+			},
+			Entry("empty component", "", "cache path component must not be empty"),
+			Entry("absolute path", "/tmp/cache", "cache path component contains invalid characters: /tmp/cache"),
+			Entry("path separator", "container/id", "cache path component contains invalid characters: container/id"),
+			Entry("current directory", ".", "cache path component contains invalid characters: ."),
+			Entry("parent directory", "..", "cache path component contains invalid characters: .."),
+		)
+	})
 
 	Context("Checking GetSriovNumVfs function", func() {
 		It("Assuming existing interface", func() {
@@ -195,9 +245,7 @@ var _ = Describe("Utils", func() {
 		var tmpDir string
 
 		BeforeEach(func() {
-			var err error
-			tmpDir, err = os.MkdirTemp("", "sriov")
-			Expect(err).ToNot(HaveOccurred())
+			tmpDir = GinkgoT().TempDir()
 		})
 		It("should save all the netConf struct to the cache file without dns", func() {
 			netconf := &sriovtypes.NetConf{NetConf: cnitypes.NetConf{CNIVersion: "1.0.0"}, SriovNetConf: sriovtypes.SriovNetConf{DeviceID: "0000:af:06.0"}}
@@ -232,5 +280,21 @@ var _ = Describe("Utils", func() {
 			Expect(netconf.CNIVersion).To(Equal(newNetConf.CNIVersion))
 			Expect(netconf.DNS.Domain).To(Equal(newNetConf.DNS.Domain))
 		})
+
+		DescribeTable("should reject invalid cache path components",
+			func(containerID, podIfName string) {
+				netconf := &sriovtypes.NetConf{}
+				err := SaveNetConf(containerID, tmpDir, podIfName, netconf)
+				Expect(err).To(HaveOccurred())
+
+				entries, err := os.ReadDir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(BeEmpty())
+			},
+			Entry("empty container ID", "", "net1"),
+			Entry("container ID path traversal", "../escape", "net1"),
+			Entry("empty interface name", "container-id", ""),
+			Entry("interface name path traversal", "container-id", "../escape"),
+		)
 	})
 })


### PR DESCRIPTION
this is a follow up for pr #436, adding unit tests and tightening the regex to only possible PCI address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for PCI addresses, container IDs, and interface names.
  * Prevented invalid path components and PCI addresses from reaching filesystem operations.
  * Rejected PCI device numbers outside the valid range.
* **Tests**
  * Added coverage for invalid configuration values, cache inputs, PCI allocator operations, and network configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->